### PR TITLE
feat(init): add guided cross-platform onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ cd your-project
 mancode init
 ```
 
+`init` guides you through the agent choice and marks a detected agent as a hint;
+it never silently installs every adapter. Choose one or more adapters, or choose
+**All platforms**. In a brand-new empty folder it asks whether to initialize a
+generic project, so users do not need to know `git init` or `npm init -y` first.
+Adding Git or a manifest later is safe; run `mancode refresh-project` to update
+the detected project facts and installed static adapters.
+
 ## 
 
 After initialization, keep using your coding agent normally. `solo` mode runs by
@@ -299,6 +306,8 @@ npm install -g mancode
 cd your-project
 mancode init
 mancode init --platform cursor
+mancode init --platform codex,cursor
+mancode init --platform all
 ```
 
 Supported platforms:
@@ -317,11 +326,14 @@ Supported platforms:
 
 ```bash
 mancode init --force      # Reinstall while preserving scanned tokens
-mancode init --yes        # Skip confirmations for CI usage
+mancode init --yes        # Skip generic-project confirmation (use --platform in CI)
 mancode init --team       # Force-enable team mode
 mancode init --no-team    # Force-disable team mode
 mancode init --style NAME # Save a default style preference
-mancode init --platform PLATFORM # Initialize for claude-code, cursor, codex, copilot, or zcode
+mancode init --platform PLATFORMS # One or more: claude-code,cursor,codex,copilot,zcode, or all
+mancode init --empty      # Allow a safe empty directory in non-interactive scripts
+mancode init --lang zh-CN # Explicit initialization language (zh-CN or en)
+mancode refresh-project   # Refresh facts after Git or project files are added
 mancode install --force   # Reinstall adapter while preserving scanned tokens
 mancode install --minimal # Install only solo-mode essentials
 ```
@@ -542,10 +554,11 @@ mancode/
 
 ### `mancode init` says "not a project directory"
 
-mancode requires either a `.git` directory or a recognized project manifest
-(such as `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `pom.xml`,
-`build.gradle`, `build.gradle.kts`, `Package.swift`, or `pubspec.yaml`). Run `mancode init` inside
-a git repository or a supported project directory.
+In an interactive terminal, an empty directory is offered as a new generic
+project. No Git or package command is required. To protect existing files,
+non-empty unrecognized directories are rejected; enter the project directory
+instead. For scripts, use `mancode init --empty --platform <platform>` only for
+a deliberately empty directory.
 
 ### Claude Code hooks not triggering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -63,6 +63,11 @@ cd your-project
 mancode init
 ```
 
+`init` 会引导选择 Agent，并把检测到的 Agent 仅作为提示；不会悄悄安装全部适配器。
+可以选择一个、多个或“全部平台”。全新空目录会询问是否初始化为通用项目，因此用户不必
+先知道 `git init` 或 `npm init -y`。之后再加入 Git 或项目 manifest 也安全，执行
+`mancode refresh-project` 即可刷新项目事实和已安装的静态适配器。
+
 
 
 初始化后，继续正常使用你的编码代理。`solo` 默认自动生效：日常训练，零仪式感。遇到需要
@@ -261,6 +266,8 @@ npm install -g mancode
 cd your-project
 mancode init
 mancode init --platform cursor
+mancode init --platform codex,cursor
+mancode init --platform all
 ```
 
 平台支持：
@@ -278,11 +285,14 @@ mancode init --platform cursor
 
 ```bash
 mancode init --force      # 重装并保留已扫描 token
-mancode init --yes        # CI 场景跳过确认
+mancode init --yes        # 跳过通用项目确认（CI 中仍需 --platform）
 mancode init --team       # 强制启用团队模式
 mancode init --no-team    # 强制禁用团队模式
 mancode init --style NAME # 保存默认审美偏好
-mancode init --platform PLATFORM # 初始化 claude-code、cursor、codex、copilot 或 zcode
+mancode init --platform PLATFORMS # 一个或多个：claude-code,cursor,codex,copilot,zcode，或 all
+mancode init --empty      # 非交互脚本中允许安全的空目录
+mancode init --lang zh-CN # 显式指定初始化语言（zh-CN 或 en）
+mancode refresh-project   # 后续加入 Git 或项目文件后刷新项目事实
 mancode install --force   # 重装适配并保留已扫描 token
 mancode install --minimal # 只安装 solo 必需文件
 ```
@@ -492,7 +502,9 @@ mancode/
 
 ### `mancode init` 提示"not a project directory"
 
-mancode 要求目标目录有 `.git` 或已识别的项目 manifest（如 `package.json`、`pyproject.toml`、`go.mod`、`Cargo.toml`、`pom.xml`、`build.gradle`、`build.gradle.kts`、`Package.swift` 或 `pubspec.yaml`）。请在 git 仓库或支持的项目目录中运行 `mancode init`。
+交互式终端中的空目录会询问是否初始化为通用项目，不需要 Git 或 npm 命令。为了保护已有
+文件，未识别且非空的目录仍会被拒绝；请进入真正的项目目录。脚本里只应针对明确为空的
+目录使用 `mancode init --empty --platform <platform>`。
 
 ### Claude Code hooks 不生效
 

--- a/scripts/windows-smoke.mjs
+++ b/scripts/windows-smoke.mjs
@@ -5,7 +5,10 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
 const cliPath = path.join(repoRoot, 'dist', 'cli.js');
 const root = await mkdtemp(path.join(tmpdir(), 'mancode-windows-smoke-'));
 const noToolPath = Object.fromEntries(
@@ -14,6 +17,44 @@ const noToolPath = Object.fromEntries(
 noToolPath.PATH = '';
 
 try {
+  const emptyProject = path.join(root, 'empty-project');
+  await mkdir(emptyProject, { recursive: true });
+  runCli(emptyProject, [
+    'init',
+    '--empty',
+    '--platform',
+    'codex,cursor',
+    '--lang',
+    'en',
+  ]);
+  const emptyConfig = await readJson(
+    path.join(emptyProject, '.mancode', 'config.json'),
+  );
+  assert(
+    JSON.stringify(emptyConfig.platforms) ===
+      JSON.stringify(['codex', 'cursor']),
+    'empty multi-platform init did not preserve adapter selection',
+  );
+  await readFile(path.join(emptyProject, 'AGENTS.md'), 'utf8');
+  await readFile(
+    path.join(emptyProject, '.cursor', 'rules', 'mancode-solo.mdc'),
+    'utf8',
+  );
+  await writeFile(
+    path.join(emptyProject, 'package.json'),
+    `${JSON.stringify({ name: 'empty-project', dependencies: { react: 'latest' } })}\n`,
+    'utf8',
+  );
+  runCli(emptyProject, ['refresh-project']);
+  const refreshedAgents = await readFile(
+    path.join(emptyProject, 'AGENTS.md'),
+    'utf8',
+  );
+  assert(
+    refreshedAgents.includes('React'),
+    'refresh-project did not regenerate static adapter context',
+  );
+
   const codexProject = await createProject('codex-project');
   runCli(codexProject, ['init', '--platform', 'codex']);
   const codexState = await readJson(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { init } from './commands/init.js';
 import { install } from './commands/install.js';
 import { listPlatforms } from './commands/list-platforms.js';
 import { manps } from './commands/manps.js';
+import { refreshProject } from './commands/refresh-project.js';
 import { refreshStyle } from './commands/refresh-style.js';
 import { status } from './commands/status.js';
 import { uninstall } from './commands/uninstall.js';
@@ -26,9 +27,14 @@ program
   .option('--team', 'Force enable team mode (MVP-2)')
   .option('--no-team', 'Force disable team mode (MVP-2)')
   .option('--style <name>', 'Specify aesthetic style (MVP-2)')
-  .option('--platform <platform>', 'Initial adapter platform (MVP-3)')
+  .option('--platform <platforms>', 'Adapters: comma-separated names or all')
+  .option('--empty', 'Initialize a safe empty directory as a generic project')
+  .option('--lang <locale>', 'Initialization language: zh-CN or en')
   .action(async (options) => {
-    const code = await init(process.cwd(), options);
+    const code = await init(process.cwd(), {
+      ...options,
+      interactive: Boolean(process.stdin.isTTY && process.stdout.isTTY),
+    });
     process.exitCode = code;
   });
 
@@ -122,6 +128,16 @@ program
   .description('Refresh project profile and rescan applicable design tokens')
   .action(async () => {
     const code = await refreshStyle(process.cwd());
+    process.exitCode = code;
+  });
+
+program
+  .command('refresh-project')
+  .description(
+    'Refresh detected project facts after adding Git or project files',
+  )
+  .action(async () => {
+    const code = await refreshProject(process.cwd());
     process.exitCode = code;
   });
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,8 +1,11 @@
 import { promises as fs } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { validateClaudeCodeSettings } from '../installers/claude-code.js';
 import { installMancodeCore } from '../installers/common.js';
+import { MANCODE_CURSOR_RULE_FILES } from '../installers/cursor.js';
+import { MODE_NAMES } from '../installers/mode-skills.js';
 import {
   type PlatformName,
   getPlatformInstaller,
@@ -10,11 +13,20 @@ import {
 import { detectTeamStatus } from '../system/detect-team.js';
 import { detectSystemDeps } from '../system/detect.js';
 import {
+  type InitLocale,
+  type InitPrompter,
+  createTerminalPrompter,
+  detectInitLocale,
+  detectPlatformHints,
+  parsePlatformSelection,
+} from '../system/init-onboarding.js';
+import {
   PROJECT_MANIFESTS,
   detectProjectProfile,
   primaryUiLibrary,
 } from '../system/project-profile.js';
 import { scanAesthetics } from '../system/scan-aesthetics.js';
+import { ALL_AGENTS } from '../templates/agents/index.js';
 import { VERSION } from '../version.js';
 
 /**
@@ -54,12 +66,14 @@ export interface MancodeState {
   // MVP-2: 团队检测
   teamModeAutoDetected: boolean;
   contributors: number;
+  /** Whether init started from an empty directory rather than detected project files. */
+  projectMode?: 'generic' | 'detected';
 }
 
 export interface InitOptions {
   /** --force: 覆盖已有配置 */
   force?: boolean;
-  /** --yes: 跳过所有确认（CI 用）*/
+  /** --yes: 跳过通用项目确认；CI 仍需显式指定平台 */
   yes?: boolean;
   /** --team / --no-team: 强制启用/禁用团队模式（MVP-2）*/
   team?: boolean;
@@ -67,6 +81,14 @@ export interface InitOptions {
   style?: string;
   /** --platform <platform>: initial adapter platform (MVP-3) */
   platform?: string;
+  /** --empty: allow a safe, empty directory to become a generic project. */
+  empty?: boolean;
+  /** --lang <locale>: onboarding language (zh-CN or en). */
+  lang?: string;
+  /** Internal CLI flag. Undefined preserves the programmatic API's legacy default. */
+  interactive?: boolean;
+  /** Injectable prompt adapter for terminal and tests. */
+  prompter?: InitPrompter;
 }
 
 /**
@@ -84,7 +106,7 @@ export interface InitOptions {
  * - ✅ 创建 8 个文件
  * - ✅ --force / --yes 参数
  * - ✅ --team / --no-team / --style 参数（MVP-2）
- * - ⏸️ 交互式确认（默认静默安装，--yes 保持兼容）
+ * - ✅ 空目录确认与多平台交互选择
  *
  * @param rootDir 目标项目根目录，默认 process.cwd()
  * @param options CLI 参数
@@ -97,72 +119,117 @@ export async function init(
   const mancodeDir = path.join(rootDir, '.mancode');
   const stateFile = path.join(mancodeDir, 'state.json');
   const wasInitialized = await pathExists(stateFile);
-  let reinstallSnapshots: FileSnapshot[] = [];
+  let mutationSnapshots: FileSnapshot[] = [];
+  let directorySnapshots: DirectorySnapshot[] = [];
+  const locale = detectInitLocale(options.lang);
+  if (!locale) {
+    console.error(`✗  Unsupported init language: ${options.lang}`);
+    console.error('   Supported values: zh-CN, en');
+    return EXIT_INIT_FAILED;
+  }
 
   // 1. 幂等检查
   if (wasInitialized) {
     if (!options.force) {
-      console.log('ℹ️  mancode already initialized.');
+      console.log(
+        localize(
+          locale,
+          'ℹ️  mancode 已经初始化。',
+          'ℹ️  mancode already initialized.',
+        ),
+      );
       console.log(`   ${stateFile}`);
-      console.log('   Run `mancode init --force` to reinstall.');
+      console.log(
+        localize(
+          locale,
+          '   运行 `mancode init --force` 重新安装。',
+          '   Run `mancode init --force` to reinstall.',
+        ),
+      );
       return EXIT_ALREADY_INITIALIZED;
     }
-    try {
-      reinstallSnapshots = await snapshotFiles([
-        stateFile,
-        path.join(mancodeDir, 'config.json'),
-        path.join(mancodeDir, 'project-profile.json'),
-        path.join(mancodeDir, 'aesthetics', 'style-tokens.json'),
-      ]);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(`✗  Cannot snapshot existing mancode state: ${message}`);
-      return EXIT_INIT_FAILED;
-    }
     // --force: 继续，覆盖已有配置
-    console.log('⚠️  Reinstalling with --force...');
+    console.log(
+      localize(
+        locale,
+        '⚠️  正在使用 --force 重新安装...',
+        '⚠️  Reinstalling with --force...',
+      ),
+    );
   }
 
   // 2. 校验目标目录存在
   if (!(await pathExists(rootDir))) {
-    console.error(`✗  Target directory does not exist: ${rootDir}`);
-    return EXIT_NOT_A_PROJECT_DIR;
-  }
-
-  // 2.1 校验是项目目录（git 或任一常见项目 manifest）
-  const isGitRepo = await pathExists(path.join(rootDir, '.git'));
-  const hasManifest = await Promise.any(
-    PROJECT_MANIFESTS.map(async (name) => {
-      if (await pathExists(path.join(rootDir, name))) return true;
-      throw new Error('manifest missing');
-    }),
-  ).catch(() => false);
-
-  if (!isGitRepo && !hasManifest) {
-    console.error(`✗  Not a project directory: ${rootDir}`);
-    console.error('   (No .git or recognized project manifest found)');
-    console.error('');
     console.error(
-      '   Run mancode init in a git repository or a recognized project directory.',
+      localize(
+        locale,
+        `✗  目标目录不存在：${rootDir}`,
+        `✗  Target directory does not exist: ${rootDir}`,
+      ),
     );
     return EXIT_NOT_A_PROJECT_DIR;
   }
 
+  // 2.1 校验是项目目录（git 或任一常见项目 manifest）。空目录可明确作为通用项目初始化。
+  const isGitRepo = await pathExists(path.join(rootDir, '.git'));
+  const hasManifest = await hasProjectManifest(rootDir);
+  let isGenericProject = false;
+
+  if (!isGitRepo && !hasManifest) {
+    const genericSafety = await canInitializeGenericProject(rootDir);
+    if (!genericSafety.ok) {
+      printNotProjectDirectory(rootDir, locale, genericSafety.reason);
+      return EXIT_NOT_A_PROJECT_DIR;
+    }
+    const prompter =
+      options.prompter ??
+      (options.interactive ? createTerminalPrompter() : null);
+    const confirmed =
+      options.empty || options.yes
+        ? true
+        : prompter
+          ? await prompter.confirmGenericProject({ rootDir, locale })
+          : false;
+    if (!confirmed) {
+      if (options.interactive) {
+        console.log(
+          locale === 'zh-CN' ? '已取消初始化。' : 'Initialization cancelled.',
+        );
+        return EXIT_USER_CANCEL;
+      }
+      printNotProjectDirectory(rootDir, locale, 'empty');
+      return EXIT_NOT_A_PROJECT_DIR;
+    }
+    isGenericProject = true;
+  }
+
   try {
     // 3. 检测系统依赖
-    console.log('✓  检测系统依赖...');
+    console.log(
+      localize(
+        locale,
+        '✓  检测系统依赖...',
+        '✓  Checking system dependencies...',
+      ),
+    );
     const deps = await detectSystemDeps();
 
     if (!deps.git) {
       console.log(
-        '⚠️  Git not found (optional). Team auto-detection will use solo defaults.',
+        localize(
+          locale,
+          '⚠️  未找到 Git（可选）。团队自动检测将使用 solo 默认值。',
+          '⚠️  Git not found (optional). Team auto-detection will use solo defaults.',
+        ),
       );
     } else {
       console.log('   git ✓');
     }
 
     // 4. 检测项目类型
-    console.log('✓  检测项目类型...');
+    console.log(
+      localize(locale, '✓  检测项目类型...', '✓  Detecting project type...'),
+    );
     const profile = await detectProjectProfile(rootDir);
     const profileStack = [...profile.languages, ...profile.frameworks];
     const techStackStr = profileStack.join(' + ') || 'Unknown';
@@ -175,39 +242,120 @@ export async function init(
         console.log(`   UI: ${uiLibraryStr}`);
       }
     } else if (hasManifest) {
-      console.log('   project manifest found, no known framework dependencies');
+      console.log(
+        localize(
+          locale,
+          '   已发现项目 manifest，未识别到框架依赖',
+          '   Project manifest found; no known framework dependencies',
+        ),
+      );
     } else {
       console.log(
-        '   (No recognized manifest found, profile confidence is low)',
+        localize(
+          locale,
+          '   （未发现已识别的 manifest，项目画像置信度较低）',
+          '   (No recognized manifest found; profile confidence is low)',
+        ),
       );
     }
 
     const existingPlatform = wasInitialized
       ? await readExistingInitPlatform(stateFile)
       : null;
-    const initPlatformName =
-      options.platform ?? existingPlatform ?? DEFAULT_INIT_PLATFORM;
-    const installer = getPlatformInstaller(initPlatformName);
-    if (!installer) {
-      console.error(`✗  Unsupported platform: ${initPlatformName}`);
+    const platformHints = await detectPlatformHints(rootDir);
+    const selectedPlatforms = await selectInitPlatforms({
+      option: options.platform,
+      existingPlatform,
+      hints: platformHints,
+      interactive: options.interactive,
+      prompter: options.prompter,
+      locale,
+      yes: options.yes,
+    });
+    if (!selectedPlatforms) {
+      console.error(
+        locale === 'zh-CN'
+          ? '✗  未选择平台。请重新运行并选择平台，或使用 --platform codex,cursor / --platform all。'
+          : '✗  No platform selected. Choose one interactively or pass --platform codex,cursor / --platform all.',
+      );
       return EXIT_INIT_FAILED;
     }
+    if (selectedPlatforms.length === 0) {
+      console.error('✗  No platform selected.');
+      return EXIT_INIT_FAILED;
+    }
+    const firstPlatform = selectedPlatforms[0];
+    if (!firstPlatform) {
+      console.error('✗  No platform selected.');
+      return EXIT_INIT_FAILED;
+    }
+    const installers = selectedPlatforms.map(getPlatformInstaller);
+    if (installers.some((installer) => !installer)) {
+      console.error(`✗  Unsupported platform: ${options.platform}`);
+      return EXIT_INIT_FAILED;
+    }
+    const typedInstallers = installers.filter(
+      (installer): installer is NonNullable<typeof installer> =>
+        installer !== null,
+    );
+    const onlyPlatformHint =
+      platformHints.length === 1 ? platformHints[0] : null;
+    const detectedPrimary =
+      onlyPlatformHint && selectedPlatforms.includes(onlyPlatformHint)
+        ? onlyPlatformHint
+        : null;
+    const primaryPlatform =
+      existingPlatform && selectedPlatforms.includes(existingPlatform)
+        ? existingPlatform
+        : (detectedPrimary ?? firstPlatform);
+
+    const managedFiles = getInitManagedFilePaths(rootDir, selectedPlatforms);
+    mutationSnapshots = await snapshotFiles(managedFiles);
+    directorySnapshots = await snapshotDirectories(managedFiles, [
+      path.join(mancodeDir, 'workflows'),
+      path.join(mancodeDir, 'preseason-reports'),
+    ]);
 
     // 4.1 检测多人协作（MVP-2）
     const team = await detectTeamStatus(rootDir);
     const existingPreferences = wasInitialized
-      ? await readExistingInitPreferences(mancodeDir, installer.name)
+      ? await readExistingInitPreferences(mancodeDir, primaryPlatform)
       : {};
     const initialMinimal = existingPreferences.minimal ?? false;
+    const existingTeamMode =
+      existingPreferences.forceTeamMode === true
+        ? 'on'
+        : (existingPreferences.teamMode ?? 'auto');
     const teamModeEnabled =
-      options.team ?? existingPreferences.forceTeamMode ?? team.isTeam;
+      options.team ??
+      (existingTeamMode === 'on'
+        ? true
+        : existingTeamMode === 'off'
+          ? false
+          : team.isTeam);
     if (options.team === true) {
-      console.log('   team: forced on (--team)');
+      console.log(
+        localize(
+          locale,
+          '   团队模式：强制开启（--team）',
+          '   team: forced on (--team)',
+        ),
+      );
     } else if (options.team === false) {
-      console.log('   team: forced off (--no-team)');
+      console.log(
+        localize(
+          locale,
+          '   团队模式：强制关闭（--no-team）',
+          '   team: forced off (--no-team)',
+        ),
+      );
     } else if (team.isTeam) {
       console.log(
-        `   team: ${team.contributors} contributors (/manteam available)`,
+        localize(
+          locale,
+          `   团队模式：${team.contributors} 位贡献者（可使用 /manteam）`,
+          `   team: ${team.contributors} contributors (/manteam available)`,
+        ),
       );
     }
 
@@ -215,7 +363,7 @@ export async function init(
       version: VERSION,
       currentMode: 'solo',
       lastMode: 'solo',
-      platform: installer.name,
+      platform: primaryPlatform,
       initializedAt: new Date().toISOString(),
       techStack: techStackStr,
       uiLibrary: uiLibraryStr,
@@ -224,10 +372,11 @@ export async function init(
       skippedSteps: [],
       teamModeAutoDetected: teamModeEnabled,
       contributors: team.contributors,
+      projectMode: isGenericProject ? 'generic' : 'detected',
     };
 
     // 5. 预检用户 Claude Code settings，避免坏 JSON 导致半初始化。
-    if (installer.name === 'claude-code') {
+    if (selectedPlatforms.includes('claude-code')) {
       await validateClaudeCodeSettings(rootDir);
     }
 
@@ -251,22 +400,45 @@ export async function init(
           options.team === undefined && wasInitialized
             ? undefined
             : options.team === true,
+        teamMode:
+          options.team === undefined && wasInitialized
+            ? undefined
+            : options.team === true
+              ? 'on'
+              : options.team === false
+                ? 'off'
+                : 'auto',
         defaultStyle:
           options.style === undefined && wasInitialized
             ? undefined
             : (options.style ?? null),
-        platforms: [installer.name],
+        platforms: selectedPlatforms,
         platformOptions: {
-          [installer.name]: { minimal: initialMinimal },
+          ...Object.fromEntries(
+            selectedPlatforms.map((platform) => [
+              platform,
+              { minimal: initialMinimal },
+            ]),
+          ),
         },
       },
       wasInitialized,
     );
 
     // 8. 审美扫描（profile 确认 UI 资产时才扫）。必须早于静态平台规则生成。
-    let styleLine = '  .mancode/aesthetics/        # style-tokens.json (空)';
+    let styleLine = localize(
+      locale,
+      '  .mancode/aesthetics/        # style-tokens.json（空）',
+      '  .mancode/aesthetics/        # style-tokens.json (empty)',
+    );
     if (profile.uiAssets === 'detected') {
-      console.log('✓  扫描审美 token...');
+      console.log(
+        localize(
+          locale,
+          '✓  扫描审美 token...',
+          '✓  Scanning design tokens...',
+        ),
+      );
       const tokens = await scanAesthetics(rootDir, uiLibrary);
       const tokensPath = path.join(
         mancodeDir,
@@ -283,69 +455,143 @@ export async function init(
         const colorCount = Object.keys(tokens.colors).length;
         const fontCount = Object.keys(tokens.fonts).length;
         console.log(
-          `   ${colorCount} colors, ${fontCount} fonts (match: high)`,
+          localize(
+            locale,
+            `   ${colorCount} 个颜色，${fontCount} 个字体（匹配度：高）`,
+            `   ${colorCount} colors, ${fontCount} fonts (match: high)`,
+          ),
         );
-        styleLine = `  .mancode/aesthetics/        # style-tokens.json (${colorCount} colors)`;
+        styleLine = localize(
+          locale,
+          `  .mancode/aesthetics/        # style-tokens.json（${colorCount} 个颜色）`,
+          `  .mancode/aesthetics/        # style-tokens.json (${colorCount} colors)`,
+        );
       } else if (tokens.matchLevel === 'low') {
         console.log(
-          '   UI assets detected, no reusable tokens found (match: low)',
+          localize(
+            locale,
+            '   已检测到 UI 资源，未找到可复用 token（匹配度：低）',
+            '   UI assets detected; no reusable tokens found (match: low)',
+          ),
         );
-        styleLine =
-          '  .mancode/aesthetics/        # style-tokens.json (low match)';
+        styleLine = localize(
+          locale,
+          '  .mancode/aesthetics/        # style-tokens.json（低匹配）',
+          '  .mancode/aesthetics/        # style-tokens.json (low match)',
+        );
       } else {
-        console.log('   No design tokens found (match: none)');
-        styleLine =
-          '  .mancode/aesthetics/        # style-tokens.json (no tokens)';
+        console.log(
+          localize(
+            locale,
+            '   未找到设计 token（无匹配）',
+            '   No design tokens found (match: none)',
+          ),
+        );
+        styleLine = localize(
+          locale,
+          '  .mancode/aesthetics/        # style-tokens.json（无 token）',
+          '  .mancode/aesthetics/        # style-tokens.json (no tokens)',
+        );
       }
     }
 
     // 9. 安装平台适配。
-    console.log(`✓  安装 ${installer.displayName} 适配...`);
-    await installer.install(rootDir, {
-      techStack: profileStack,
-      uiLibrary,
-      projectProfile: profile,
-      minimal: initialMinimal,
-      force: options.force,
-    });
+    for (const installer of typedInstallers) {
+      console.log(
+        localize(
+          locale,
+          `✓  安装 ${installer.displayName} 适配器...`,
+          `✓  Installing ${installer.displayName} adapter...`,
+        ),
+      );
+      await installer.install(rootDir, {
+        techStack: profileStack,
+        uiLibrary,
+        projectProfile: profile,
+        minimal: initialMinimal,
+        force: options.force,
+      });
+    }
 
     // 10. 完成
     console.log('');
-    console.log('✓  mancode initialized.');
-    console.log('');
-    console.log('Created:');
-    console.log('  .mancode/state.json         # 项目状态');
-    console.log('  .mancode/project-profile.json # 检测到的项目事实');
-    console.log('  .mancode/config.json        # 配置');
     console.log(
-      '  .mancode/hooks/             # SessionStart + UserPromptSubmit',
+      localize(locale, '✓  mancode 初始化完成。', '✓  mancode initialized.'),
+    );
+    console.log('');
+    console.log(localize(locale, '已创建：', 'Created:'));
+    console.log(
+      localize(
+        locale,
+        '  .mancode/state.json         # 项目状态',
+        '  .mancode/state.json         # project state',
+      ),
+    );
+    console.log(
+      localize(
+        locale,
+        '  .mancode/project-profile.json # 检测到的项目事实',
+        '  .mancode/project-profile.json # detected project facts',
+      ),
+    );
+    console.log(
+      localize(
+        locale,
+        '  .mancode/config.json        # 配置',
+        '  .mancode/config.json        # configuration',
+      ),
+    );
+    console.log(
+      localize(
+        locale,
+        '  .mancode/hooks/             # SessionStart + UserPromptSubmit',
+        '  .mancode/hooks/             # SessionStart + UserPromptSubmit',
+      ),
     );
     console.log(styleLine);
     console.log('  .mancode/logs/              # hooks.log');
-    printPlatformCreatedFiles(installer.name);
+    for (const platform of selectedPlatforms)
+      printPlatformCreatedFiles(platform, locale);
     console.log('');
-    console.log('Next:');
-    console.log('  mancode status              # Show project state');
-    if (installer.name === 'claude-code') {
-      console.log('  (Restart Claude Code to load hooks)');
-    } else if (installer.name === 'codex') {
+    console.log(localize(locale, '下一步：', 'Next:'));
+    console.log(
+      localize(
+        locale,
+        '  mancode status              # 显示项目状态',
+        '  mancode status              # Show project state',
+      ),
+    );
+    if (selectedPlatforms.includes('claude-code')) {
       console.log(
-        '  (If skills do not appear, restart the ChatGPT desktop app or Codex session)',
+        localize(
+          locale,
+          '  （重启 Claude Code 以加载 hooks）',
+          '  (Restart Claude Code to load hooks)',
+        ),
+      );
+    }
+    if (selectedPlatforms.includes('codex')) {
+      console.log(
+        localize(
+          locale,
+          '  （如果 skills 未出现，请重启 ChatGPT 桌面应用或 Codex 会话）',
+          '  (If skills do not appear, restart the ChatGPT desktop app or Codex session)',
+        ),
       );
     }
 
     return EXIT_OK;
   } catch (err) {
-    if (wasInitialized) {
-      await restoreFiles(reinstallSnapshots);
-    } else {
-      await fs.rm(stateFile, { force: true });
-      await fs.rm(path.join(mancodeDir, 'project-profile.json'), {
-        force: true,
-      });
-    }
+    await restoreFiles(mutationSnapshots);
+    await removeNewEmptyDirectories(directorySnapshots);
     const msg = err instanceof Error ? err.message : String(err);
-    console.error(`✗  mancode init failed: ${msg}`);
+    console.error(
+      localize(
+        locale,
+        `✗  mancode 初始化失败：${msg}`,
+        `✗  mancode init failed: ${msg}`,
+      ),
+    );
     return EXIT_INIT_FAILED;
   }
 }
@@ -354,6 +600,7 @@ async function updateConfigOptions(
   mancodeDir: string,
   patch: {
     forceTeamMode?: boolean;
+    teamMode?: 'auto' | 'on' | 'off';
     defaultStyle?: string | null;
     platforms: PlatformName[];
     platformOptions: Partial<Record<PlatformName, { minimal: boolean }>>;
@@ -403,14 +650,29 @@ async function updateConfigOptions(
 async function readExistingInitPreferences(
   mancodeDir: string,
   platform: PlatformName,
-): Promise<{ forceTeamMode?: boolean; minimal?: boolean }> {
+): Promise<{
+  forceTeamMode?: boolean;
+  teamMode?: 'auto' | 'on' | 'off';
+  minimal?: boolean;
+}> {
   try {
     const config = JSON.parse(
       await fs.readFile(path.join(mancodeDir, 'config.json'), 'utf-8'),
     ) as Record<string, unknown>;
-    const preferences: { forceTeamMode?: boolean; minimal?: boolean } = {};
+    const preferences: {
+      forceTeamMode?: boolean;
+      teamMode?: 'auto' | 'on' | 'off';
+      minimal?: boolean;
+    } = {};
     if (typeof config.forceTeamMode === 'boolean') {
       preferences.forceTeamMode = config.forceTeamMode;
+    }
+    if (
+      config.teamMode === 'auto' ||
+      config.teamMode === 'on' ||
+      config.teamMode === 'off'
+    ) {
+      preferences.teamMode = config.teamMode;
     }
     if (
       Array.isArray(config.platforms) &&
@@ -444,9 +706,187 @@ async function readExistingInitPlatform(
   }
 }
 
+async function selectInitPlatforms(input: {
+  option?: string;
+  existingPlatform: PlatformName | null;
+  hints: PlatformName[];
+  interactive?: boolean;
+  prompter?: InitPrompter;
+  locale: InitLocale;
+  yes?: boolean;
+}): Promise<PlatformName[] | null> {
+  if (input.option !== undefined) {
+    return parsePlatformSelection(input.option);
+  }
+  // Preserve the historical direct-function API and force reinstall behavior.
+  if (input.existingPlatform) return [input.existingPlatform];
+  if (input.yes && input.interactive !== undefined) {
+    return input.hints.length === 1 ? input.hints : null;
+  }
+  if (input.interactive) {
+    const prompter = input.prompter ?? createTerminalPrompter();
+    return prompter.selectPlatforms({
+      locale: input.locale,
+      detected: input.hints,
+    });
+  }
+  if (input.interactive === false) {
+    // A non-interactive CLI must be deterministic. A single runtime hint is safe;
+    // otherwise require --platform rather than silently installing Claude Code.
+    return input.hints.length === 1 ? input.hints : null;
+  }
+  return [DEFAULT_INIT_PLATFORM];
+}
+
+async function hasProjectManifest(rootDir: string): Promise<boolean> {
+  for (const name of PROJECT_MANIFESTS) {
+    if (await pathExists(path.join(rootDir, name))) return true;
+  }
+  return false;
+}
+
+async function canInitializeGenericProject(
+  rootDir: string,
+): Promise<{ ok: true } | { ok: false; reason: 'unsafe' | 'nonempty' }> {
+  const resolved = path.resolve(rootDir);
+  if (
+    resolved === path.parse(resolved).root ||
+    resolved === path.resolve(os.homedir())
+  ) {
+    return { ok: false, reason: 'unsafe' };
+  }
+  try {
+    const entries = await fs.readdir(resolved);
+    const meaningfulEntries = entries.filter(
+      (entry) => !['.DS_Store', 'Thumbs.db', '.gitkeep'].includes(entry),
+    );
+    return meaningfulEntries.length === 0
+      ? { ok: true }
+      : { ok: false, reason: 'nonempty' };
+  } catch {
+    return { ok: false, reason: 'unsafe' };
+  }
+}
+
+function printNotProjectDirectory(
+  rootDir: string,
+  locale: InitLocale,
+  reason: 'unsafe' | 'nonempty' | 'empty',
+): void {
+  if (locale === 'zh-CN') {
+    console.error(`✗  当前目录不是可初始化的项目目录：${rootDir}`);
+    if (reason === 'unsafe') {
+      console.error('   为避免误写，不能在 Home 目录或磁盘根目录初始化。');
+    } else if (reason === 'nonempty') {
+      console.error(
+        '   未识别到项目文件，且目录中已有文件。请先进入项目目录。',
+      );
+    } else {
+      console.error(
+        '   未发现 .git 或项目文件。交互终端中可确认通用项目，或使用 --empty。',
+      );
+    }
+    return;
+  }
+  console.error(`✗  Not a project directory: ${rootDir}`);
+  if (reason === 'unsafe') {
+    console.error(
+      '   Refusing to initialize a home directory or filesystem root.',
+    );
+  } else if (reason === 'nonempty') {
+    console.error(
+      '   No project files were detected and the directory is not empty.',
+    );
+  } else {
+    console.error(
+      '   No .git or recognized project manifest found. Use an interactive terminal or --empty for a new project.',
+    );
+  }
+}
+
 interface FileSnapshot {
   filePath: string;
   content: string | null;
+}
+
+interface DirectorySnapshot {
+  dirPath: string;
+  existed: boolean;
+}
+
+function getInitManagedFilePaths(
+  rootDir: string,
+  platforms: PlatformName[],
+): string[] {
+  const files = [
+    '.mancode/state.json',
+    '.mancode/config.json',
+    '.mancode/project-profile.json',
+    '.mancode/aesthetics/style-tokens.json',
+    '.mancode/hooks/session-start.mjs',
+    '.mancode/hooks/user-prompt-submit.mjs',
+    '.mancode/logs/hooks.log',
+    '.mancode/memory/prd.md',
+    '.mancode/memory/spec.md',
+    '.mancode/memory/decisions.md',
+  ];
+  if (platforms.includes('claude-code')) {
+    files.push(
+      '.mancode/hooks/session-start.sh',
+      '.mancode/hooks/user-prompt-submit.sh',
+      '.claude/settings.json',
+      '.claude/skills/man8/SKILL.md',
+      '.claude/skills/solo/SKILL.md',
+      '.claude/skills/mancode-solo.md',
+      '.claude/skills/mancode-man8.md',
+    );
+    for (const mode of MODE_NAMES) {
+      files.push(
+        `.claude/skills/${mode}/SKILL.md`,
+        `.claude/skills/mancode-${mode}.md`,
+      );
+    }
+    for (const agent of ALL_AGENTS) {
+      files.push(`.claude/agents/${agent.name}.md`);
+    }
+  }
+  if (platforms.includes('cursor')) {
+    files.push('.cursor/rules/mancode-man8.mdc', '.cursor/commands/man8.md');
+    for (const fileName of MANCODE_CURSOR_RULE_FILES) {
+      files.push(`.cursor/rules/${fileName}`);
+    }
+    for (const mode of MODE_NAMES) {
+      files.push(`.cursor/commands/${mode}.md`);
+    }
+  }
+  if (platforms.includes('codex') || platforms.includes('zcode')) {
+    files.push('AGENTS.md', '.agents/skills/man8/SKILL.md');
+    for (const mode of MODE_NAMES) {
+      files.push(`.agents/skills/${mode}/SKILL.md`);
+    }
+  }
+  if (platforms.includes('codex')) {
+    files.push('.codex/skills/man8/SKILL.md');
+    for (const mode of MODE_NAMES) {
+      files.push(`.codex/skills/${mode}/SKILL.md`);
+    }
+  }
+  if (platforms.includes('zcode')) {
+    files.push('.zcode/skills/man8/SKILL.md');
+    for (const mode of MODE_NAMES) {
+      files.push(`.zcode/skills/${mode}/SKILL.md`);
+    }
+  }
+  if (platforms.includes('copilot')) {
+    files.push(
+      '.github/copilot-instructions.md',
+      '.github/prompts/man8.prompt.md',
+    );
+    for (const mode of MODE_NAMES) {
+      files.push(`.github/prompts/${mode}.prompt.md`);
+    }
+  }
+  return [...new Set(files.map((file) => path.join(rootDir, file)))];
 }
 
 async function snapshotFiles(filePaths: string[]): Promise<FileSnapshot[]> {
@@ -464,6 +904,26 @@ async function snapshotFiles(filePaths: string[]): Promise<FileSnapshot[]> {
   );
 }
 
+async function snapshotDirectories(
+  filePaths: string[],
+  additionalDirectories: string[] = [],
+): Promise<DirectorySnapshot[]> {
+  const directories = new Set<string>(additionalDirectories);
+  for (const filePath of filePaths) {
+    let current = path.dirname(filePath);
+    while (current !== path.dirname(current)) {
+      directories.add(current);
+      current = path.dirname(current);
+    }
+  }
+  return Promise.all(
+    [...directories].map(async (dirPath) => ({
+      dirPath,
+      existed: await pathExists(dirPath),
+    })),
+  );
+}
+
 async function restoreFiles(snapshots: FileSnapshot[]): Promise<void> {
   for (const snapshot of snapshots) {
     if (snapshot.content === null) {
@@ -475,6 +935,21 @@ async function restoreFiles(snapshots: FileSnapshot[]): Promise<void> {
   }
 }
 
+async function removeNewEmptyDirectories(
+  snapshots: DirectorySnapshot[],
+): Promise<void> {
+  const candidates = snapshots
+    .filter((snapshot) => !snapshot.existed)
+    .sort((a, b) => b.dirPath.length - a.dirPath.length);
+  for (const { dirPath } of candidates) {
+    try {
+      await fs.rmdir(dirPath);
+    } catch {
+      // Preserve non-empty directories and any user files they contain.
+    }
+  }
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -483,10 +958,25 @@ function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && 'code' in error;
 }
 
-function printPlatformCreatedFiles(platform: PlatformName): void {
+function printPlatformCreatedFiles(
+  platform: PlatformName,
+  locale: InitLocale,
+): void {
   if (platform === 'claude-code') {
-    console.log('  .claude/settings.json       # hook 注册');
-    console.log('  .claude/skills/             # solo + MVP-2 slash skills');
+    console.log(
+      localize(
+        locale,
+        '  .claude/settings.json       # hook 注册',
+        '  .claude/settings.json       # hook registration',
+      ),
+    );
+    console.log(
+      localize(
+        locale,
+        '  .claude/skills/             # solo + MVP-2 slash skills',
+        '  .claude/skills/             # solo + MVP-2 slash skills',
+      ),
+    );
     return;
   }
   if (platform === 'cursor') {
@@ -504,6 +994,14 @@ function printPlatformCreatedFiles(platform: PlatformName): void {
     return;
   }
   console.log('  .github/copilot-instructions.md # Copilot instructions');
+}
+
+function localize(
+  locale: InitLocale,
+  chinese: string,
+  english: string,
+): string {
+  return locale === 'zh-CN' ? chinese : english;
 }
 
 async function pathExists(p: string): Promise<boolean> {

--- a/src/commands/refresh-project.ts
+++ b/src/commands/refresh-project.ts
@@ -1,0 +1,288 @@
+import { randomUUID } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import {
+  type PlatformName,
+  getPlatformInstaller,
+} from '../installers/registry.js';
+import { detectTeamStatus } from '../system/detect-team.js';
+import {
+  PROJECT_MANIFESTS,
+  detectProjectProfile,
+  primaryUiLibrary,
+} from '../system/project-profile.js';
+
+export const EXIT_OK = 0;
+export const EXIT_NOT_INITIALIZED = 1;
+export const EXIT_CORRUPT_STATE = 2;
+export const EXIT_REFRESH_FAILED = 3;
+
+/** Refresh facts that can change after a generic project later gains Git or a manifest. */
+export async function refreshProject(
+  rootDir: string = process.cwd(),
+): Promise<number> {
+  const mancodeDir = path.join(rootDir, '.mancode');
+  const statePath = path.join(mancodeDir, 'state.json');
+  if (!(await pathExists(statePath))) {
+    console.error('✗  mancode not initialized.');
+    console.error('   Run `mancode init` first.');
+    return EXIT_NOT_INITIALIZED;
+  }
+
+  const state = await readRequiredState(statePath);
+  if (!state) {
+    console.error('✗  .mancode/state.json is corrupt or incomplete.');
+    console.error('   Run `mancode init --force` to repair it.');
+    return EXIT_CORRUPT_STATE;
+  }
+
+  let factsWritten = false;
+  try {
+    const [profile, team, hasGit, hasManifest] = await Promise.all([
+      detectProjectProfile(rootDir),
+      detectTeamStatus(rootDir),
+      pathExists(path.join(rootDir, '.git')),
+      hasProjectManifest(rootDir),
+    ]);
+    const uiLibrary = primaryUiLibrary(profile);
+    const stack = [...profile.languages, ...profile.frameworks];
+    const config = await readJson(path.join(mancodeDir, 'config.json'));
+    const configuredTeam =
+      config.forceTeamMode === true
+        ? true
+        : config.teamMode === 'on'
+          ? true
+          : config.teamMode === 'off'
+            ? false
+            : team.isTeam;
+    const nextState = {
+      ...state,
+      techStack: stack.join(' + ') || profile.projectKind,
+      uiLibrary: uiLibrary ?? 'None',
+      projectMode: hasGit || hasManifest ? 'detected' : 'generic',
+      teamModeAutoDetected: configuredTeam,
+      contributors: team.contributors,
+    };
+    await writeProjectFacts(
+      statePath,
+      path.join(mancodeDir, 'project-profile.json'),
+      `${JSON.stringify(nextState, null, 2)}\n`,
+      `${JSON.stringify(profile, null, 2)}\n`,
+    );
+    factsWritten = true;
+
+    const refreshedPlatforms = await refreshStaticPlatforms(
+      rootDir,
+      config,
+      state.platform,
+      stack,
+      uiLibrary,
+      profile,
+    );
+    console.log('✓  Project facts refreshed.');
+    console.log(
+      `   ${hasGit ? 'Git detected' : 'No Git repository'} | ${hasManifest ? 'project manifest detected' : 'generic project'}`,
+    );
+    console.log(
+      `   Stack: ${nextState.techStack} | UI: ${nextState.uiLibrary}`,
+    );
+    if (refreshedPlatforms.length > 0) {
+      console.log(`   Refreshed adapters: ${refreshedPlatforms.join(', ')}`);
+    }
+    console.log(
+      '   Run `mancode refresh-style` if UI files or dependencies changed.',
+    );
+    return EXIT_OK;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`✗  Project refresh failed: ${message}`);
+    if (factsWritten) {
+      console.error(
+        '   Project facts were saved, but one or more static adapters remain stale.',
+      );
+    }
+    return EXIT_REFRESH_FAILED;
+  }
+}
+
+async function hasProjectManifest(rootDir: string): Promise<boolean> {
+  for (const manifest of PROJECT_MANIFESTS) {
+    if (await pathExists(path.join(rootDir, manifest))) return true;
+  }
+  return false;
+}
+
+async function writeProjectFacts(
+  statePath: string,
+  profilePath: string,
+  stateContent: string,
+  profileContent: string,
+): Promise<void> {
+  await Promise.all([
+    ensureReplaceableFile(statePath),
+    ensureReplaceableFile(profilePath),
+  ]);
+  const previousProfile = await readOptionalText(profilePath);
+  const stateTemp = temporaryPath(statePath);
+  const profileTemp = temporaryPath(profilePath);
+  let profileReplaced = false;
+  try {
+    await Promise.all([
+      fs.writeFile(stateTemp, stateContent, 'utf-8'),
+      fs.writeFile(profileTemp, profileContent, 'utf-8'),
+    ]);
+    await fs.rename(profileTemp, profilePath);
+    profileReplaced = true;
+    await fs.rename(stateTemp, statePath);
+  } catch (error) {
+    if (profileReplaced) {
+      if (previousProfile === null) {
+        await fs.rm(profilePath, { force: true });
+      } else {
+        await replaceTextFile(profilePath, previousProfile);
+      }
+    }
+    throw error;
+  } finally {
+    await Promise.all([
+      fs.rm(stateTemp, { force: true }),
+      fs.rm(profileTemp, { force: true }),
+    ]);
+  }
+}
+
+async function ensureReplaceableFile(filePath: string): Promise<void> {
+  try {
+    const entry = await fs.lstat(filePath);
+    if (!entry.isFile()) {
+      throw new Error(`cannot replace non-file path: ${filePath}`);
+    }
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') return;
+    throw error;
+  }
+}
+
+async function replaceTextFile(
+  filePath: string,
+  content: string,
+): Promise<void> {
+  const tempPath = temporaryPath(filePath);
+  try {
+    await fs.writeFile(tempPath, content, 'utf-8');
+    await fs.rename(tempPath, filePath);
+  } finally {
+    await fs.rm(tempPath, { force: true });
+  }
+}
+
+async function readOptionalText(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, 'utf-8');
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+function temporaryPath(filePath: string): string {
+  return path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+}
+
+async function refreshStaticPlatforms(
+  rootDir: string,
+  config: Record<string, unknown>,
+  fallbackPlatform: unknown,
+  stack: string[],
+  uiLibrary: string | null,
+  profile: Awaited<ReturnType<typeof detectProjectProfile>>,
+): Promise<string[]> {
+  const platforms = configuredPlatforms(config, fallbackPlatform).filter(
+    (platform) => platform !== 'claude-code',
+  );
+  const refreshed: string[] = [];
+  for (const platform of platforms) {
+    const installer = getPlatformInstaller(platform);
+    if (!installer) continue;
+    await installer.install(rootDir, {
+      techStack: stack,
+      uiLibrary,
+      projectProfile: profile,
+      minimal: platformIsMinimal(config, platform),
+      force: true,
+    });
+    refreshed.push(installer.displayName);
+  }
+  return refreshed;
+}
+
+function configuredPlatforms(
+  config: Record<string, unknown>,
+  fallbackPlatform: unknown,
+): PlatformName[] {
+  const configured = Array.isArray(config.platforms)
+    ? config.platforms
+    : [fallbackPlatform];
+  return configured.filter(
+    (platform): platform is PlatformName =>
+      typeof platform === 'string' && getPlatformInstaller(platform) !== null,
+  );
+}
+
+function platformIsMinimal(
+  config: Record<string, unknown>,
+  platform: PlatformName,
+): boolean {
+  if (!isRecord(config.platformOptions)) return false;
+  const options = config.platformOptions[platform];
+  return isRecord(options) && options.minimal === true;
+}
+
+async function readJson(filePath: string): Promise<Record<string, unknown>> {
+  try {
+    const value = JSON.parse(await fs.readFile(filePath, 'utf-8'));
+    return isRecord(value) ? value : {};
+  } catch {
+    return {};
+  }
+}
+
+async function readRequiredState(
+  filePath: string,
+): Promise<Record<string, unknown> | null> {
+  let state: Record<string, unknown>;
+  try {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+    state = parsed;
+  } catch {
+    return null;
+  }
+  return typeof state.version === 'string' &&
+    typeof state.currentMode === 'string' &&
+    typeof state.platform === 'string'
+    ? state
+    : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -11,6 +11,7 @@ import {
   getPlatformInstallers,
 } from '../installers/registry.js';
 import { detectTeamStatus } from '../system/detect-team.js';
+import { PROJECT_MANIFESTS } from '../system/project-profile.js';
 import {
   type WorkflowMode,
   type WorkflowOutcome,
@@ -47,6 +48,7 @@ export interface StatusState {
   currentWorkflowMode?: string | null;
   teamModeAutoDetected?: boolean;
   contributors?: number;
+  projectMode?: 'generic' | 'detected';
 }
 
 export interface StatusOptions {
@@ -96,6 +98,7 @@ export interface StatusResult {
     }>;
   } | null;
   platformStatus: Record<string, PlatformStatus>;
+  projectRefreshRecommended: boolean;
 }
 
 interface DetectedTeamStatus {
@@ -108,6 +111,7 @@ interface DetectedTeamStatus {
 interface StatusConfig {
   platforms?: string[];
   forceTeamMode?: boolean;
+  teamMode?: 'auto' | 'on' | 'off';
 }
 
 /**
@@ -162,6 +166,7 @@ export async function status(
     hookInjection,
     teamStatus,
     currentWorkflow,
+    projectRefreshRecommended,
   ] = await Promise.all([
     getProjectName(rootDir),
     checkHooks(rootDir),
@@ -169,6 +174,7 @@ export async function status(
     estimateHookInjection(rootDir),
     detectTeamStatus(rootDir),
     getCurrentWorkflow(rootDir, state.currentTask ?? null),
+    shouldRefreshProject(rootDir, state),
   ]);
   const effectiveTeam = getEffectiveTeamStatus(state, config, teamStatus);
 
@@ -185,6 +191,7 @@ export async function status(
     team: effectiveTeam,
     currentWorkflow,
     platformStatus: {},
+    projectRefreshRecommended,
   };
   result.platformStatus = await checkPlatformStatus(rootDir, result.platforms);
 
@@ -196,6 +203,19 @@ export async function status(
   }
 
   return EXIT_OK;
+}
+
+async function shouldRefreshProject(
+  rootDir: string,
+  state: StatusState,
+): Promise<boolean> {
+  if (state.projectMode !== 'generic') return false;
+  const hasGit = await pathExists(path.join(rootDir, '.git'));
+  if (hasGit) return true;
+  for (const manifest of PROJECT_MANIFESTS) {
+    if (await pathExists(path.join(rootDir, manifest))) return true;
+  }
+  return false;
 }
 
 async function checkPlatformStatus(
@@ -303,16 +323,24 @@ function getEffectiveTeamStatus(
   const configuredTeam =
     config.forceTeamMode === true
       ? true
+      : config.teamMode === 'on'
+        ? true
+        : config.teamMode === 'off'
+          ? false
+          : (state.teamModeAutoDetected ?? detected.isTeam);
+  const forced = config.teamMode === 'on' || config.forceTeamMode === true;
+  const autoDetected =
+    config.forceTeamMode === true ||
+    config.teamMode === 'on' ||
+    config.teamMode === 'off'
+      ? false
       : (state.teamModeAutoDetected ?? detected.isTeam);
-  const forced = config.forceTeamMode === true;
 
   return {
     ...detected,
     isTeam: configuredTeam,
     contributors: Math.max(detected.contributors, state.contributors ?? 0, 1),
-    autoDetected: forced
-      ? false
-      : (state.teamModeAutoDetected ?? detected.isTeam),
+    autoDetected,
     forced,
   };
 }
@@ -475,6 +503,11 @@ function printText(r: StatusResult): void {
   console.log(`Style:       ${r.uiLibrary}`);
   console.log(`Initialized: ${r.initializedAt}`);
   console.log(`Team:        ${formatTeamStatus(r.team)}`);
+  if (r.projectRefreshRecommended) {
+    console.log(
+      'Project:     new Git or project files detected; run `mancode refresh-project`.',
+    );
+  }
   if (r.currentWorkflow) {
     const stepMax = workflowStepMax(r.currentWorkflow.mode);
     console.log(

--- a/src/system/init-onboarding.ts
+++ b/src/system/init-onboarding.ts
@@ -1,0 +1,165 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { stdin, stdout } from 'node:process';
+import { createInterface } from 'node:readline/promises';
+import {
+  PLATFORM_INSTALLERS,
+  type PlatformName,
+} from '../installers/registry.js';
+
+export type InitLocale = 'zh-CN' | 'en';
+
+export interface InitPrompter {
+  confirmGenericProject(context: {
+    rootDir: string;
+    locale: InitLocale;
+  }): Promise<boolean>;
+  selectPlatforms(context: {
+    locale: InitLocale;
+    detected: PlatformName[];
+  }): Promise<PlatformName[] | null>;
+}
+
+const ALL_PLATFORMS = Object.keys(PLATFORM_INSTALLERS) as PlatformName[];
+
+export function detectInitLocale(
+  override?: string,
+  environment: NodeJS.ProcessEnv = process.env,
+  systemLocale: string = Intl.DateTimeFormat().resolvedOptions().locale,
+): InitLocale | null {
+  if (override) return parseLocale(override);
+  const environmentLocale =
+    environment.LC_ALL ?? environment.LC_MESSAGES ?? environment.LANG;
+  return parseLocale(environmentLocale) ?? parseLocale(systemLocale) ?? 'en';
+}
+
+function parseLocale(value?: string): InitLocale | null {
+  if (!value) return null;
+  const normalized = value.toLowerCase().replace('_', '-');
+  if (normalized === 'zh' || normalized.startsWith('zh-')) return 'zh-CN';
+  if (normalized === 'en' || normalized.startsWith('en-')) return 'en';
+  return null;
+}
+
+export function parsePlatformSelection(value: string): PlatformName[] | null {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'all' || normalized === '全部') return [...ALL_PLATFORMS];
+  const choices = normalized
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+  if (choices.length === 0) return null;
+  if (
+    !choices.every((item): item is PlatformName => item in PLATFORM_INSTALLERS)
+  ) {
+    return null;
+  }
+  return [...new Set(choices)];
+}
+
+export async function detectPlatformHints(
+  rootDir: string,
+  environment: NodeJS.ProcessEnv = process.env,
+): Promise<PlatformName[]> {
+  const hints = new Set<PlatformName>();
+  if (environment.CLAUDECODE || environment.CLAUDE_CODE)
+    hints.add('claude-code');
+  if (environment.CODEX_HOME) hints.add('codex');
+  if (environment.CURSOR_TRACE_ID) hints.add('cursor');
+  if (environment.COPILOT_AGENT || environment.GITHUB_COPILOT)
+    hints.add('copilot');
+  const exists = async (relative: string): Promise<boolean> => {
+    try {
+      await fs.access(path.join(rootDir, relative));
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  if (await exists('.claude')) hints.add('claude-code');
+  if (await exists('.cursor')) hints.add('cursor');
+  if (await exists('.github/copilot-instructions.md')) hints.add('copilot');
+  return ALL_PLATFORMS.filter((platform) => hints.has(platform));
+}
+
+export function createTerminalPrompter(): InitPrompter {
+  return {
+    async confirmGenericProject({ rootDir, locale }) {
+      const rl = createInterface({ input: stdin, output: stdout });
+      try {
+        if (locale === 'zh-CN') {
+          console.log('当前目录没有识别到项目文件。');
+          console.log(`目录：${rootDir}`);
+          console.log('这是一个新项目吗？');
+          console.log('[y] 初始化为通用项目');
+          console.log('[n] 退出');
+          const answer = await rl.question('请选择 [y/N]: ');
+          return ['y', 'yes', '是'].includes(answer.trim().toLowerCase());
+        }
+        console.log('No project files were detected in the current directory.');
+        console.log(`Directory: ${rootDir}`);
+        console.log('Is this a new project?');
+        console.log('[y] Initialize as a generic project');
+        console.log('[n] Exit');
+        const answer = await rl.question('Choose [y/N]: ');
+        return ['y', 'yes'].includes(answer.trim().toLowerCase());
+      } finally {
+        rl.close();
+      }
+    },
+    async selectPlatforms({ locale, detected }) {
+      const rl = createInterface({ input: stdin, output: stdout });
+      try {
+        const names = ALL_PLATFORMS.map((platform, index) => {
+          const suffix = detected.includes(platform)
+            ? locale === 'zh-CN'
+              ? '（已检测到）'
+              : ' (detected)'
+            : '';
+          return `${index + 1}. ${PLATFORM_INSTALLERS[platform].displayName}${suffix}`;
+        });
+        console.log(
+          locale === 'zh-CN'
+            ? '\n选择要初始化的平台：'
+            : '\nChoose platforms to initialize:',
+        );
+        console.log(names.join('\n'));
+        console.log(locale === 'zh-CN' ? 'a. 全部平台' : 'a. All platforms');
+        console.log(
+          locale === 'zh-CN'
+            ? '可输入编号（例如 1,3）或 a。'
+            : 'Enter numbers (for example 1,3) or a.',
+        );
+        const answer = (
+          await rl.question(locale === 'zh-CN' ? '选择: ' : 'Selection: ')
+        )
+          .trim()
+          .toLowerCase();
+        if (answer === 'a' || answer === 'all' || answer === '全部')
+          return [...ALL_PLATFORMS];
+        const indexes = answer.split(',').map((item) => Number(item.trim()));
+        if (
+          !indexes.length ||
+          indexes.some(
+            (index) =>
+              !Number.isInteger(index) ||
+              index < 1 ||
+              index > ALL_PLATFORMS.length,
+          )
+        ) {
+          return null;
+        }
+        const selected: PlatformName[] = [];
+        for (const index of indexes) {
+          const platform = ALL_PLATFORMS[index - 1];
+          if (!platform) return null;
+          selected.push(platform);
+        }
+        return [...new Set(selected)];
+      } finally {
+        rl.close();
+      }
+    },
+  };
+}

--- a/src/templates/defaults.ts
+++ b/src/templates/defaults.ts
@@ -8,6 +8,7 @@ export const DEFAULT_CONFIG = {
   platforms: ['claude-code'],
   cliCommand: 'mancode',
   cliArgs: [],
+  teamMode: 'auto',
   forceTeamMode: false,
   defaultStyle: null,
   hooks: {

--- a/tests/init-onboarding.test.ts
+++ b/tests/init-onboarding.test.ts
@@ -1,0 +1,270 @@
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  EXIT_INIT_FAILED,
+  EXIT_NOT_A_PROJECT_DIR,
+  EXIT_OK,
+  init,
+} from '../src/commands/init.js';
+import {
+  EXIT_CORRUPT_STATE as EXIT_REFRESH_CORRUPT_STATE,
+  EXIT_REFRESH_FAILED,
+  refreshProject,
+} from '../src/commands/refresh-project.js';
+import type { InitPrompter } from '../src/system/init-onboarding.js';
+import {
+  detectInitLocale,
+  parsePlatformSelection,
+} from '../src/system/init-onboarding.js';
+
+describe('init onboarding', () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it('uses terminal locale with an explicit override', () => {
+    expect(detectInitLocale(undefined, { LANG: 'zh_CN.UTF-8' })).toBe('zh-CN');
+    expect(detectInitLocale('en', { LANG: 'zh_CN.UTF-8' })).toBe('en');
+    expect(detectInitLocale(undefined, {}, 'zh-CN')).toBe('zh-CN');
+    expect(detectInitLocale('fr', {})).toBeNull();
+  });
+
+  it('keeps English init output consistently English', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-locale-'));
+    dirs.push(dir);
+    await mkdir(path.join(dir, '.git'));
+
+    const logs = await captureOutput(() =>
+      init(dir, { platform: 'codex', lang: 'en' }),
+    );
+
+    expect(logs).toContain('Checking system dependencies');
+    expect(logs).toContain('Installing Codex');
+    expect(logs).not.toMatch(/检测|安装|项目状态|扫描|适配/);
+  });
+
+  it('accepts comma-separated adapters and the all shorthand', () => {
+    expect(parsePlatformSelection('codex, cursor,codex')).toEqual([
+      'codex',
+      'cursor',
+    ]);
+    expect(parsePlatformSelection('all')).toEqual([
+      'claude-code',
+      'cursor',
+      'codex',
+      'copilot',
+      'zcode',
+    ]);
+    expect(parsePlatformSelection('unknown')).toBeNull();
+  });
+
+  it('initializes a safe empty directory after an explicit confirmation', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-generic-'));
+    dirs.push(dir);
+    const prompt: InitPrompter = {
+      confirmGenericProject: async () => true,
+      selectPlatforms: async () => ['codex', 'cursor'],
+    };
+
+    expect(await init(dir, { interactive: true, prompter: prompt })).toBe(
+      EXIT_OK,
+    );
+    const state = JSON.parse(
+      await readFile(path.join(dir, '.mancode', 'state.json'), 'utf-8'),
+    );
+    const config = JSON.parse(
+      await readFile(path.join(dir, '.mancode', 'config.json'), 'utf-8'),
+    );
+    expect(state.projectMode).toBe('generic');
+    expect(state.platform).toBe('codex');
+    expect(config.platforms).toEqual(['codex', 'cursor']);
+  });
+
+  it('uses the single detected platform as primary when all are selected', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-primary-'));
+    dirs.push(dir);
+    await mkdir(path.join(dir, '.git'));
+    await mkdir(path.join(dir, '.cursor'));
+
+    expect(await init(dir, { platform: 'all' })).toBe(EXIT_OK);
+    const state = JSON.parse(
+      await readFile(path.join(dir, '.mancode', 'state.json'), 'utf-8'),
+    );
+    expect(state.platform).toBe('cursor');
+  });
+
+  it('ignores malformed files owned by an unselected platform', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-isolation-'));
+    dirs.push(dir);
+    await mkdir(path.join(dir, '.git'));
+    await mkdir(path.join(dir, '.claude', 'settings.json'), {
+      recursive: true,
+    });
+
+    expect(await init(dir, { platform: 'codex' })).toBe(EXIT_OK);
+    await expect(
+      readFile(path.join(dir, 'AGENTS.md'), 'utf-8'),
+    ).resolves.toContain('Platform adapter: Codex');
+  });
+
+  it('does not initialize an empty directory in non-interactive mode without --empty', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-generic-'));
+    dirs.push(dir);
+    expect(await init(dir, { interactive: false, platform: 'codex' })).toBe(
+      EXIT_NOT_A_PROJECT_DIR,
+    );
+  });
+
+  it('requires a platform for a non-interactive CLI when no agent is detected', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-cli-'));
+    dirs.push(dir);
+    await mkdir(path.join(dir, '.git'));
+    expect(await init(dir, { interactive: false })).toBe(EXIT_INIT_FAILED);
+  });
+
+  it('does not let --yes silently choose an adapter in a CLI', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-cli-yes-'));
+    dirs.push(dir);
+    await mkdir(path.join(dir, '.git'));
+    expect(await init(dir, { interactive: false, yes: true })).toBe(
+      EXIT_INIT_FAILED,
+    );
+  });
+
+  it('refreshes a generic project after Git and a manifest are added', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-refresh-'));
+    dirs.push(dir);
+    expect(await init(dir, { empty: true, platform: 'codex' })).toBe(EXIT_OK);
+    await mkdir(path.join(dir, '.git'));
+    await writeFile(
+      path.join(dir, 'package.json'),
+      '{"name":"later-project"}\n',
+    );
+    expect(await refreshProject(dir)).toBe(EXIT_OK);
+    const state = JSON.parse(
+      await readFile(path.join(dir, '.mancode', 'state.json'), 'utf-8'),
+    );
+    expect(state.projectMode).toBe('detected');
+  });
+
+  it('regenerates installed static adapters with refreshed project facts', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-refresh-static-'));
+    dirs.push(dir);
+    expect(await init(dir, { empty: true, platform: 'codex' })).toBe(EXIT_OK);
+    const agentsPath = path.join(dir, 'AGENTS.md');
+    const before = await readFile(agentsPath, 'utf-8');
+    await writeFile(
+      path.join(dir, 'package.json'),
+      '{"name":"app","dependencies":{"react":"latest"}}\n',
+    );
+
+    expect(await refreshProject(dir)).toBe(EXIT_OK);
+    const after = await readFile(agentsPath, 'utf-8');
+    expect(after).not.toBe(before);
+    expect(after).toContain('React');
+  });
+
+  it('refuses to overwrite a corrupt state during refresh', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-corrupt-'));
+    dirs.push(dir);
+    await mkdir(path.join(dir, '.mancode'));
+    const statePath = path.join(dir, '.mancode', 'state.json');
+    await writeFile(statePath, '{broken');
+
+    expect(await refreshProject(dir)).toBe(EXIT_REFRESH_CORRUPT_STATE);
+    expect(await readFile(statePath, 'utf-8')).toBe('{broken');
+  });
+
+  it('keeps state intact when another refresh target cannot be written', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-refresh-write-'));
+    dirs.push(dir);
+    expect(await init(dir, { empty: true, platform: 'codex' })).toBe(EXIT_OK);
+    const statePath = path.join(dir, '.mancode', 'state.json');
+    const stateBefore = await readFile(statePath, 'utf-8');
+    const profilePath = path.join(dir, '.mancode', 'project-profile.json');
+    await rm(profilePath);
+    await mkdir(profilePath);
+    await writeFile(path.join(dir, 'package.json'), '{"name":"app"}\n');
+
+    expect(await refreshProject(dir)).toBe(EXIT_REFRESH_FAILED);
+    expect(await readFile(statePath, 'utf-8')).toBe(stateBefore);
+  });
+
+  it('preserves an explicit --no-team choice during refresh', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-no-team-'));
+    dirs.push(dir);
+    await mkdir(path.join(dir, '.git'));
+    expect(await init(dir, { platform: 'codex', team: false })).toBe(EXIT_OK);
+    const config = JSON.parse(
+      await readFile(path.join(dir, '.mancode', 'config.json'), 'utf-8'),
+    );
+    expect(config.teamMode).toBe('off');
+
+    const statePath = path.join(dir, '.mancode', 'state.json');
+    const state = JSON.parse(await readFile(statePath, 'utf-8'));
+    state.teamModeAutoDetected = true;
+    await writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`);
+
+    expect(await refreshProject(dir)).toBe(EXIT_OK);
+    const refreshed = JSON.parse(await readFile(statePath, 'utf-8'));
+    expect(refreshed.teamModeAutoDetected).toBe(false);
+  });
+
+  it('rolls back earlier adapters when a later adapter fails', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-rollback-'));
+    dirs.push(dir);
+    await mkdir(path.join(dir, '.git'));
+    const customRule = path.join(
+      dir,
+      '.cursor',
+      'rules',
+      'mancode-context.mdc',
+    );
+    await mkdir(path.dirname(customRule), { recursive: true });
+    await writeFile(customRule, 'user rule\n');
+
+    expect(await init(dir, { platform: 'codex,cursor' })).toBe(
+      EXIT_INIT_FAILED,
+    );
+    await expect(
+      readFile(path.join(dir, 'AGENTS.md'), 'utf-8'),
+    ).rejects.toThrow();
+    await expect(
+      readFile(path.join(dir, '.mancode', 'config.json'), 'utf-8'),
+    ).rejects.toThrow();
+    await expect(
+      readFile(path.join(dir, '.mancode', 'state.json'), 'utf-8'),
+    ).rejects.toThrow();
+    await expect(readdir(path.join(dir, '.mancode'))).rejects.toThrow();
+    await expect(readdir(path.join(dir, '.agents'))).rejects.toThrow();
+    await expect(readFile(customRule, 'utf-8')).resolves.toBe('user rule\n');
+  });
+});
+
+async function captureOutput(fn: () => Promise<unknown>): Promise<string> {
+  const originalLog = console.log;
+  const originalError = console.error;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => lines.push(args.join(' '));
+  console.error = (...args: unknown[]) => lines.push(args.join(' '));
+  try {
+    await fn();
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+  return lines.join('\n');
+}

--- a/website/docs.html
+++ b/website/docs.html
@@ -59,7 +59,7 @@
 
         <section class="doc-section" id="install" data-searchable>
           <h2>Install &amp; initialize</h2>
-          <p>Install mancode globally, enter a repository or supported project directory, then initialize the default adapter. Node.js 20+ is required. Windows CMD, PowerShell, and Git Bash are supported natively; Git itself is optional and only improves team auto-detection. Claude Code hooks run with Node, not Bash or jq.</p>
+          <p>Install mancode globally, enter a project directory or a new empty folder, then choose the adapter or adapters to initialize. Node.js 20+ is required. Windows CMD, PowerShell, and Git Bash are supported natively; Git itself is optional and only improves team auto-detection. Claude Code hooks run with Node, not Bash or jq.</p>
           <div class="docs-steps">
             <article class="docs-step"><b>01</b><strong>Install</strong><p>Install the CLI once on your machine.</p></article>
             <article class="docs-step"><b>02</b><strong>Enter</strong><p>Run it from the project you want mancode to understand.</p></article>
@@ -70,10 +70,11 @@
 <span class="command-prompt">$</span> mancode init</code></pre><button type="button" data-copy="npm install -g mancode\ncd your-project\nmancode init">Copy</button></div>
           <h3>Initialize a specific platform</h3>
           <p>Use <code>--platform</code> when the current project should target a particular coding surface from the start.</p>
-          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode init --platform cursor</code></pre><button type="button" data-copy="mancode init --platform cursor">Copy</button></div>
+          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode init --platform codex,cursor</code></pre><button type="button" data-copy="mancode init --platform codex,cursor">Copy</button></div>
+          <p><code>mancode init</code> guides you through one, many, or all agent platforms. In an empty folder it can initialize a generic project—no <code>git init</code> or <code>npm init</code> required. Add Git or a manifest later, then run <code>mancode refresh-project</code> to update project facts and installed static adapters.</p>
           <table class="docs-table"><thead><tr><th>Option</th><th>Use it when</th><th>What it does</th></tr></thead><tbody>
             <tr><td><code>--force</code></td><td>Repair or reinstall generated configuration</td><td>Reinstalls while preserving scanned style tokens.</td></tr>
-            <tr><td><code>--yes</code></td><td>CI or a non-interactive shell</td><td>Skips confirmation prompts.</td></tr>
+            <tr><td><code>--yes</code></td><td>CI or a non-interactive shell</td><td>Skips the generic-project confirmation; pair it with <code>--platform</code>.</td></tr>
             <tr><td><code>--team</code></td><td>You need shared memory immediately</td><td>Forces team mode on.</td></tr>
             <tr><td><code>--no-team</code></td><td>This is a personal project</td><td>Forces team mode off.</td></tr>
             <tr><td><code>--style NAME</code></td><td>You have a named visual preference</td><td>Saves it as the default style preference.</td></tr>
@@ -181,7 +182,7 @@ $manteam</code></pre><button type="button" data-copy="/mamba\n/man\n/manteam">Co
 
         <section class="doc-section" id="troubleshooting" data-searchable>
           <h2>Troubleshooting</h2>
-          <h3><code>mancode init</code> says the directory is not a project</h3><p>Run it inside a git repository or one with a recognized project manifest. The initializer intentionally does not treat an arbitrary folder as a project.</p>
+          <h3><code>mancode init</code> says the directory is not a project</h3><p>An empty folder is offered as a generic project in an interactive terminal. Non-empty unrecognized folders stay protected; enter the actual project directory. In scripts, use <code>mancode init --empty --platform &lt;platform&gt;</code> only for an intentionally empty directory.</p>
           <h3>Claude Code hooks are not running</h3><p>Restart Claude Code after initialization so it reloads <code>.claude/settings.json</code>. Then run <code>mancode status</code>. If the hooks are still missing, run <code>mancode install claude-code --force</code>.</p>
           <h3>A platform is “not ready”</h3><p>The target files are missing or its managed block was changed. Run <code>mancode install &lt;platform&gt; --force</code> to regenerate mancode-owned content while preserving user content outside the markers.</p>
           <h3>Cursor rules do not trigger</h3><p>Confirm that <code>.cursor/rules/mancode-*.mdc</code> exists. Context, practice, and solo rules always apply; the higher-intensity rules activate through their descriptions, so invoke the relevant mode explicitly.</p>

--- a/website/docs.zh-CN.html
+++ b/website/docs.zh-CN.html
@@ -53,15 +53,16 @@
 
         <section class="doc-section" id="install" data-searchable>
           <h2>安装与初始化</h2>
-          <p>先全局安装 mancode，进入一个 git 仓库或已识别的项目目录，再初始化默认适配器。需要 Node.js 20+；原生支持 Windows CMD、PowerShell 和 Git Bash。Git 是可选依赖，只用于增强团队自动检测；Claude Code hooks 直接由 Node 执行，不需要 Bash 或 jq。</p>
+          <p>先全局安装 mancode，进入项目目录或全新的空目录，再选择要初始化的一个或多个适配器。需要 Node.js 20+；原生支持 Windows CMD、PowerShell 和 Git Bash。Git 是可选依赖，只用于增强团队自动检测；Claude Code hooks 直接由 Node 执行，不需要 Bash 或 jq。</p>
           <div class="docs-steps"><article class="docs-step"><b>01</b><strong>安装</strong><p>在机器上全局安装 CLI。</p></article><article class="docs-step"><b>02</b><strong>进入项目</strong><p>让 mancode 在需要理解的项目根目录运行。</p></article><article class="docs-step"><b>03</b><strong>初始化</strong><p>创建本地状态、扫描项目并安装适配器。</p></article></div>
           <div class="code-wrap"><pre><code><span class="command-prompt">$</span> npm install -g mancode
 <span class="command-prompt">$</span> cd your-project
 <span class="command-prompt">$</span> mancode init</code></pre><button type="button" data-copy="npm install -g mancode\ncd your-project\nmancode init">复制</button></div>
           <h3>指定平台初始化</h3><p>如果你知道当前项目要面向哪个 Agent，可在初始化时指定平台。</p>
-          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode init --platform cursor</code></pre><button type="button" data-copy="mancode init --platform cursor">复制</button></div>
+          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode init --platform codex,cursor</code></pre><button type="button" data-copy="mancode init --platform codex,cursor">复制</button></div>
+          <p><code>mancode init</code> 会引导选择一个、多个或全部 Agent 平台。空目录可初始化为通用项目，不需要先运行 <code>git init</code> 或 <code>npm init</code>；以后加入 Git 或 manifest 后执行 <code>mancode refresh-project</code>，同步项目事实和已安装的静态适配器。</p>
           <table class="docs-table"><thead><tr><th>选项</th><th>适用情况</th><th>作用</th></tr></thead><tbody>
-            <tr><td><code>--force</code></td><td>修复或重装生成的配置</td><td>重装时保留已扫描的风格 token。</td></tr><tr><td><code>--yes</code></td><td>CI 或无交互环境</td><td>跳过确认提示。</td></tr><tr><td><code>--team</code></td><td>立即需要团队记忆</td><td>强制开启团队模式。</td></tr><tr><td><code>--no-team</code></td><td>个人项目</td><td>强制关闭团队模式。</td></tr><tr><td><code>--style NAME</code></td><td>已有命名的审美偏好</td><td>保存为默认风格偏好。</td></tr>
+            <tr><td><code>--force</code></td><td>修复或重装生成的配置</td><td>重装时保留已扫描的风格 token。</td></tr><tr><td><code>--yes</code></td><td>CI 或无交互环境</td><td>跳过通用项目确认；应同时指定 <code>--platform</code>。</td></tr><tr><td><code>--team</code></td><td>立即需要团队记忆</td><td>强制开启团队模式。</td></tr><tr><td><code>--no-team</code></td><td>个人项目</td><td>强制关闭团队模式。</td></tr><tr><td><code>--style NAME</code></td><td>已有命名的审美偏好</td><td>保存为默认风格偏好。</td></tr>
           </tbody></table>
         </section>
 


### PR DESCRIPTION
## What changed

- Allow beginners to initialize safe empty directories without requiring Git or `npm init -y`.
- Add localized interactive platform selection for Claude Code, Cursor, Codex, Copilot, and ZCode, including multi-select and `all`.
- Add `mancode refresh-project` so projects can safely pick up Git or manifests added later.
- Preserve explicit team-mode choices and refresh installed static adapters transactionally.
- Expand Windows CMD, PowerShell, and Git Bash smoke coverage.
- Synchronize English/Chinese README and website documentation.

## Why

The previous initialization flow rejected new folders and treated Bash/Git as universal prerequisites. That blocked first-time users, especially on native Windows, and did not clearly guide them through choosing an agent platform.

## Impact

Initialization is now beginner-friendly and native across supported shells. Platform detection remains a hint rather than silently installing every adapter, while refresh keeps project metadata current when the folder evolves.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test` (396 tests)
- `npm run build`
- `npm run test:windows-smoke`
- `git diff --check`