### PR TITLE
ci: deploy website to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,31 @@
+name: Deploy website
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: website
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## What changed

- add a GitHub Pages workflow for the static `website/` directory
- deploy only after pushes to `main` or manual dispatch
- grant the workflow only the Pages permissions it needs

## Why

The repository has a ready-to-serve static site but no deployment path. GitHub Pages can host this public project site without a separate server.

## Validation

- YAML syntax check
- `git diff --check`
- verified the repository is public and the GitHub App reports admin permission