### PR TITLE
fix: preserve command casing across website

### DIFF
--- a/website/docs.css
+++ b/website/docs.css
@@ -411,6 +411,7 @@
 
 .docs-table td code {
   white-space: nowrap;
+  text-transform: none;
 }
 
 .command-list {
@@ -438,6 +439,7 @@
   font-family: var(--mono);
   font-size: 13px;
   line-height: 1.35;
+  text-transform: none;
 }
 
 .command-card header span {

--- a/website/styles.css
+++ b/website/styles.css
@@ -284,6 +284,10 @@ h3 {
   text-transform: uppercase;
 }
 
+code {
+  text-transform: none;
+}
+
 h1 {
   max-width: 820px;
   margin-bottom: 0;
@@ -483,7 +487,7 @@ h1 .orange {
   font-size: clamp(64px, 6.2vw, 94px);
   line-height: 0.8;
   letter-spacing: -0.035em;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .play-card-name span {
@@ -1379,7 +1383,11 @@ h1 .orange {
   color: var(--lime);
   font-size: 8px;
   letter-spacing: 0.1em;
-  text-transform: uppercase;
+  text-transform: none;
+}
+
+.workflow-lead .eyebrow {
+  text-transform: none;
 }
 
 .terminal-ready i {


### PR DESCRIPTION
## What changed

Preserved lowercase command and mode names throughout the Chinese and English website and documentation pages.

## Why

The global display style converted valid lowercase commands such as `solo`, `/manba`, and `mancode init` to uppercase, which could mislead users.

## Validation

- `git diff --check origin/main...HEAD`
- `npx vitest run tests/version.test.ts`
- Browser visual checks of Chinese CLI cards and English mode browser