### PR TITLE
fix: complete V3 beta release surface

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,27 @@
+name: Quality gate
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: npm test

--- a/README.en.md
+++ b/README.en.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="./LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg?style=flat-square" alt="License: AGPL-3.0" /></a>
   <a href="https://www.npmjs.com/package/mancode"><img src="https://img.shields.io/npm/v/mancode?style=flat-square" alt="npm version" /></a>
-  <img src="https://img.shields.io/badge/status-stable%20v0.3.13-green?style=flat-square" alt="Status: stable v0.3.13" />
+  <img src="https://img.shields.io/badge/status-V3%20beta%20v0.3.13-orange?style=flat-square" alt="Status: V3 beta v0.3.13" />
   <img src="https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Cursor%20%7C%20Codex%20%7C%20Copilot%20%7C%20ZCode-5865F2?style=flat-square" alt="Platforms: Claude Code, Cursor, Codex in ChatGPT desktop and CLI, GitHub Copilot, ZCode" />
 </p>
 
@@ -177,7 +177,7 @@ the original mode entries, never task/session snapshots. `mancode init
   default `solo` for lightweight implementation, or continue the full `/man`
   validation and bounded risk-review workflow.
 - **Keep workflow artifacts on disk**: save research, plans, review reports,
-  and summaries under `.mancode/local/workflows/<taskId>/`.
+  and summaries under `.mancode/<namespace>/workflows/<ULID>/`.
 - **Support team context**: use `/manteam` with confirmed typed entities under
   `.mancode/shared/`.
 - **Scan project health**: use `mancode manps` to detect stale TODOs, unused
@@ -263,7 +263,7 @@ Context Pack:
 work. A planning or research request made from default `solo` routes into `/man`.
 It inspects the project, asks only questions that can change scope, architecture,
 cost, or acceptance, and recommends 2–3 options when a decision benefits from
-guidance. It writes the plan under `.mancode/local/workflows/<taskId>/` only
+guidance. It writes the plan under `.mancode/local/workflows/<ULID>/` only
 after the requirements are ready.
 
 Finishing the plan does not automatically start the full workflow. At the plan
@@ -350,9 +350,9 @@ it should behave, and why previous decisions were made.
 
 ## Installation
 
-**Status**: stable v0.3.13. Claude Code, Cursor, Codex in the ChatGPT desktop app
-and CLI, and GitHub Copilot are supported. ZCode adapter support is included,
-with project skill discovery kept behind a verification gate before release.
+**Status**: V3 beta v0.3.13. Claude Code, Cursor, Codex in the ChatGPT desktop
+app and CLI, GitHub Copilot, and ZCode adapters are included. Stable release
+still requires the five-host real-session acceptance and the `context beta` B1 gate.
 
 Requires Node.js 20 or newer. macOS, Linux, Windows CMD, PowerShell, and Git Bash
 are supported. Git is optional: without it, initialization continues with solo
@@ -426,6 +426,8 @@ mancode list-platforms
 mancode team identity create --name "<name>"
 mancode context session new --client <platform>
 mancode workflow create <man|manba|manteam> "<task>" --session <id>
+mancode workflow list --json
+mancode workflow show <namespace:ULID> --json
 mancode context resume <local:ULID|shared:ULID> --session <id>
 mancode workflow requirements <namespace:ULID> finalize --file <requirements.json> --expected-revision <n> --session <id>
 mancode workflow plan <namespace:ULID> revise --file <plan.md> --expected-revision <n> --session <id>
@@ -507,9 +509,11 @@ mancode context session new --client codex
 mancode workflow create man "refactor auth module" --session <id>
 mancode workflow requirements <local:ULID> finalize --file requirements.json --expected-revision <n> --session <id>
 mancode workflow plan <local:ULID> revise --file plan.md --expected-revision <n> --session <id>
+mancode workflow plan <local:ULID> confirm --plan-decision <plan_only|governed_execution> --expected-revision <n> --session <id>
 mancode workflow review <local:ULID> apply --file review-ledger.json --expected-revision <n> --session <id>
 mancode workflow verify <local:ULID> apply --file verification-ledger.json --expected-revision <n> --session <id>
 mancode workflow complete <local:ULID> --expected-revision <n> --session <id>
+mancode context compact --dry-run
 ```
 
 ### `mancode manps`
@@ -635,23 +639,34 @@ Ensure the `.cursor/rules/mancode-*.mdc` files exist. Rules with
 Mode-specific rules (manba, man, manteam, manps) trigger based on the
 description field — invoke them by asking for `/manba` or similar.
 
-### How to do a clean reinstall
+### How to reinstall V3 adapters
 
 ```bash
-mancode uninstall --all --force
-mancode init
-mancode install <platform>
+mancode uninstall claude-code --force
+mancode uninstall cursor --force
+mancode uninstall codex --force
+mancode uninstall copilot --force
+mancode uninstall zcode --force
+mancode install claude-code
+mancode install cursor
+mancode install codex
+mancode install copilot
+mancode install zcode
 ```
 
-### How to completely remove mancode
+V3 authority is protected, so `mancode uninstall --all` does not delete workflow
+authority. To inspect removable runtime records, run
+`mancode context compact --dry-run` first.
+
+### How to remove the CLI
 
 ```bash
-mancode uninstall --all --force
 npm uninstall -g mancode
 ```
 
-This removes `.mancode/`, platform config files, and mancode hooks from
-`.claude/settings.json`. User-authored rules and instructions are preserved.
+Uninstalling each platform removes its mancode bootstrap while preserving
+user-authored rules, instructions, and V3 workflow data. The `--all` form is only
+supported for projects explicitly initialized with `mancode init --legacy`.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="./LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg?style=flat-square" alt="许可证：AGPL-3.0" /></a>
   <a href="https://www.npmjs.com/package/mancode"><img src="https://img.shields.io/npm/v/mancode?style=flat-square" alt="npm 版本" /></a>
-  <img src="https://img.shields.io/badge/status-stable%20v0.3.13-green?style=flat-square" alt="状态：稳定版 v0.3.13" />
+  <img src="https://img.shields.io/badge/status-V3%20beta%20v0.3.13-orange?style=flat-square" alt="状态：V3 Beta v0.3.13" />
   <img src="https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Cursor%20%7C%20Codex%20%7C%20Copilot%20%7C%20ZCode-5865F2?style=flat-square" alt="平台：Claude Code、Cursor、ChatGPT 桌面端 Codex、Codex CLI、GitHub Copilot、ZCode" />
 </p>
 
@@ -155,7 +155,7 @@ AGENTS.md                        # Codex（ChatGPT 桌面端/CLI）：托管 ins
 - **在存在 UI 时匹配现有设计系统**：检查项目 UI 依赖、Tailwind 配置、CSS 变量和已有组件，让 agent 复用现有颜色、字体和交互模式。
 - **先把需求和计划对齐**：`/man` 会调研项目、引导澄清会改变方案的需求、推荐可行选项并生成可确认的持久计划；计划完成后不会自动进入完整实施。
 - **自由选择执行强度**：计划确认后，可只保留计划、交给默认 `solo` 轻量开发，或继续完整 `/man` 的验证与有界风险审查。
-- **保留工作流产物**：调研、计划、审查报告和总结会保存到 `.mancode/local/workflows/<taskId>/`。
+- **保留工作流产物**：调研、计划、审查报告和总结会保存到 `.mancode/<namespace>/workflows/<ULID>/`。
 - **支持团队上下文**：`/manteam` 通过 `.mancode/shared/` 的类型化实体共享已确认信息。
 - **扫描项目健康度**：`mancode manps` 检测陈旧 TODO、未使用依赖、风险依赖和硬编码设计值。
 
@@ -228,7 +228,7 @@ mancode 不把“当前模式”写进持久状态。需要某种工作方式时
 `solo`，当用户要求先调研、给方案或出计划时，也会进入 `/man`。它会先了解项目，
 只追问会改变范围、架构、成本或验收的问题；适合由系统推荐的决策会给出 2–3 个
 方案、优缺点和明确建议。需求足够清楚后，计划才会写入
-`.mancode/local/workflows/<taskId>/plan.md`。
+`.mancode/local/workflows/<ULID>/plan.md`。
 
 计划完成不会自动开始完整开发。用户在计划关卡选择：交给 `solo` 按已确认计划
 轻量开发、继续完整 `/man`、只保留计划，或修改计划。只有选择完整 `/man` 才继续
@@ -305,9 +305,9 @@ src/components/
 
 ## 安装
 
-**状态**：稳定版 v0.3.13。Claude Code、Cursor、ChatGPT 桌面端中的 Codex、
-Codex CLI 和 GitHub Copilot 均已支持。ZCode adapter 已接入，但项目级 skill
-发现路径在发布前仍作为验证门禁。
+**状态**：V3 Beta v0.3.13。Claude Code、Cursor、ChatGPT 桌面端中的 Codex、
+Codex CLI 和 GitHub Copilot 均已接入；ZCode adapter 已接入。正式稳定发布仍需
+完成五平台真实宿主验收和 `context beta` B1 门禁。
 
 需要 Node.js 20 或更高版本。原生支持 macOS、Linux、Windows CMD、
 PowerShell 和 Git Bash。Git 是可选依赖：未安装时仍可初始化，只会把团队
@@ -379,6 +379,8 @@ mancode list-platforms
 mancode team identity create --name "<name>"
 mancode context session new --client <platform>
 mancode workflow create <man|manba|manteam> "<task>" --session <id>
+mancode workflow list --json
+mancode workflow show <namespace:ULID> --json
 mancode context resume <local:ULID|shared:ULID> --session <id>
 mancode workflow requirements <namespace:ULID> finalize --file <requirements.json> --expected-revision <n> --session <id>
 mancode workflow plan <namespace:ULID> revise --file <plan.md> --expected-revision <n> --session <id>
@@ -458,9 +460,11 @@ mancode context session new --client codex
 mancode workflow create man "refactor auth module" --session <id>
 mancode workflow requirements <local:ULID> finalize --file requirements.json --expected-revision <n> --session <id>
 mancode workflow plan <local:ULID> revise --file plan.md --expected-revision <n> --session <id>
+mancode workflow plan <local:ULID> confirm --plan-decision <plan_only|governed_execution> --expected-revision <n> --session <id>
 mancode workflow review <local:ULID> apply --file review-ledger.json --expected-revision <n> --session <id>
 mancode workflow verify <local:ULID> apply --file verification-ledger.json --expected-revision <n> --session <id>
 mancode workflow complete <local:ULID> --expected-revision <n> --session <id>
+mancode context compact --dry-run
 ```
 
 ### `mancode manps`
@@ -575,23 +579,33 @@ mancode/
 （context、practice、solo）在每次对话加载。模式规则（manba、man、manteam、
 manps）按 description 触发——输入 `/manba` 等关键词即可激活。
 
-### 如何完全重装
+### 如何重装 V3 适配器
 
 ```bash
-mancode uninstall --all --force
-mancode init
-mancode install <platform>
+mancode uninstall claude-code --force
+mancode uninstall cursor --force
+mancode uninstall codex --force
+mancode uninstall copilot --force
+mancode uninstall zcode --force
+mancode install claude-code
+mancode install cursor
+mancode install codex
+mancode install copilot
+mancode install zcode
 ```
 
-### 如何完全卸载 mancode
+V3 authority 受保护，`mancode uninstall --all` 不会删除工作流权威数据。需要
+清理运行时保留记录时，先用 `mancode context compact --dry-run` 检查候选。
+
+### 如何移除 CLI
 
 ```bash
-mancode uninstall --all --force
 npm uninstall -g mancode
 ```
 
-这会移除 `.mancode/`、平台配置文件和 `.claude/settings.json` 中的 mancode
-hooks。用户自定义的 rules 和 instructions 会被保留。
+逐个平台卸载会移除对应的 mancode bootstrap，并保留用户自定义 rules、instructions
+和 V3 工作流数据。旧项目若明确使用 `mancode init --legacy`，才支持 legacy 的
+`mancode uninstall --all --force`。
 
 ## 常见问题
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "AI coding agent workflow harness. Five modes from practice to playoffs: stop over-engineering, reuse project context, and add multi-agent code review.",
   "type": "module",
   "license": "AGPL-3.0-only",
-  "author": "",
-  "homepage": "https://github.com/whitelonng/mancode",
+  "author": "whitelonng",
+  "homepage": "https://whitelonng.github.io/mancode/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/whitelonng/mancode.git"

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -872,8 +872,19 @@ function printV3Text(result: V3StatusResult): void {
   console.log(
     `Identity:    ${result.localIdentity.displayName ?? 'not configured'}`,
   );
+  const sessionEvidenceDetail = result.sessionEvidence.ready
+    ? 'ready'
+    : [
+        ...result.sessionEvidence.explicitRequiredPlatforms,
+        ...result.sessionEvidence.missingPlatforms.filter(
+          (platform) =>
+            !result.sessionEvidence.explicitRequiredPlatforms.includes(
+              platform,
+            ),
+        ),
+      ].join(', ') || 'none recorded';
   console.log(
-    `Session evidence: ${result.sessionEvidence.ready ? 'ready' : `explicit required (${result.sessionEvidence.explicitRequiredPlatforms.join(', ')})`}`,
+    `Session evidence: ${result.sessionEvidence.ready ? 'ready' : `explicit required (${sessionEvidenceDetail})`}`,
   );
   if (result.compatibility.failures.length > 0) {
     console.log(`Compatibility: ${result.compatibility.failures.join(', ')}`);

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -104,7 +104,7 @@ async function uninstallV3(
   if (!platform || options.all) {
     console.error('✗  mancode authority is protected from bulk uninstall.');
     console.error(
-      '   Remove a single bootstrap with `mancode uninstall <platform>`, or complete an explicit mancode archive/migration workflow first.',
+      '   Remove a single bootstrap with `mancode uninstall <platform>`. Inspect runtime retention with `mancode context compact --dry-run`; V3 workflow authority is not bulk-deleted.',
     );
     return EXIT_V3_AUTHORITY_PROTECTED;
   }

--- a/src/commands/workflow.ts
+++ b/src/commands/workflow.ts
@@ -16,9 +16,10 @@ import {
   startV3SoloHandoff,
 } from '../context/solo-handoff.js';
 import { completeV3Task } from '../context/task-complete.js';
-import { parseTaskRef } from '../context/task-ref.js';
+import { formatTaskRef, parseTaskRef } from '../context/task-ref.js';
 import { recordV3Verification } from '../context/verification-record.js';
 import { createV3Workflow } from '../context/workflow-create.js';
+import type { WorkflowMetadataV3 } from '../context/workflow-metadata.js';
 import { updateV3Workflow } from '../context/workflow-update.js';
 import { detectTeamAssessmentSignals } from '../system/detect-team.js';
 import {
@@ -216,6 +217,15 @@ async function workflowV3(
   args: string[],
   options: WorkflowOptions,
 ): Promise<number> {
+  if (subcommand === 'list') {
+    return workflowListV3(rootDir, args, options);
+  }
+  if (subcommand === 'show') {
+    return workflowShowV3(rootDir, args, options);
+  }
+  if (subcommand === 'clean') {
+    return workflowCleanV3(options);
+  }
   if (subcommand === 'create') {
     return workflowCreateV3(rootDir, args, options);
   }
@@ -254,6 +264,144 @@ async function workflowV3(
     'MANCODE_V3_OPERATION_NOT_IMPLEMENTED',
     `workflow ${subcommand} is not yet implemented for mancode authority.`,
   );
+}
+
+async function workflowListV3(
+  rootDir: string,
+  args: string[],
+  options: WorkflowOptions,
+): Promise<number> {
+  if (args.length !== 0) {
+    return printV3Error(
+      options.json,
+      'MANCODE_WORKFLOW_LIST_ARGUMENT_INVALID',
+      'Use: workflow list [--json].',
+      EXIT_INVALID_ARG,
+    );
+  }
+  try {
+    const project = await readV3CommandProject(rootDir);
+    const workflows = await project.store.listWorkflowMetadata();
+    if (options.json) {
+      return printV3Result(true, {
+        schemaVersion: 1,
+        workflows,
+      });
+    }
+    if (workflows.length === 0) {
+      console.log('No mancode workflows.');
+      return EXIT_OK;
+    }
+    const active = workflows.filter((item) =>
+      ['in_progress', 'planned', 'blocked'].includes(item.status),
+    ).length;
+    console.log(
+      `mancode workflows (${workflows.length} total, ${active} active)`,
+    );
+    console.log('');
+    for (const metadata of workflows) {
+      console.log(formatV3WorkflowRow(metadata));
+    }
+    return EXIT_OK;
+  } catch (error) {
+    return printV3Error(
+      options.json,
+      v3ErrorCode(error, 'MANCODE_V3_WORKFLOW_LIST_FAILED'),
+      error instanceof Error
+        ? error.message
+        : 'Unable to list mancode workflows.',
+    );
+  }
+}
+
+async function workflowShowV3(
+  rootDir: string,
+  args: string[],
+  options: WorkflowOptions,
+): Promise<number> {
+  const requested = args[0];
+  if (!requested || args.length !== 1) {
+    return printV3Error(
+      options.json,
+      'MANCODE_WORKFLOW_SHOW_ARGUMENT_INVALID',
+      'Use: workflow show <namespace:ULID> [--json].',
+      EXIT_INVALID_ARG,
+    );
+  }
+  try {
+    const project = await readV3CommandProject(rootDir);
+    const location = await project.store.locateTask(requested);
+    const [snapshot, activeChildren] = await Promise.all([
+      project.store.readTaskSnapshot(location.taskRef),
+      project.store.listActiveChildTaskRefs(location.taskRef),
+    ]);
+    const result = {
+      schemaVersion: 1,
+      taskRef: location.taskRef,
+      metadata: snapshot.metadata,
+      aggregate: snapshot.aggregate,
+      aggregateError: snapshot.aggregateError,
+      activeChildren,
+    };
+    if (options.json) return printV3Result(true, result);
+
+    const metadata = snapshot.metadata;
+    console.log(`Workflow:     ${formatTaskRef(metadata.taskRef)}`);
+    console.log(`Task:         ${metadata.task}`);
+    console.log(`Mode:         ${metadata.workflowMode}`);
+    console.log(`Status:       ${metadata.status}`);
+    console.log(
+      `Current step: ${metadata.currentStep}/${maxV3WorkflowStep(metadata.workflowMode)}`,
+    );
+    console.log(`Revision:     ${metadata.revision}`);
+    console.log(`Visibility:   ${metadata.visibility}`);
+    console.log(`Coordination: ${metadata.coordination}`);
+    console.log(`Updated:      ${metadata.updatedAt}`);
+    if (metadata.blockingReason !== null) {
+      console.log(`Blocked:      ${metadata.blockingReason}`);
+    }
+    if (activeChildren.length > 0) {
+      console.log(
+        `Children:     ${activeChildren.map(formatTaskRef).join(', ')}`,
+      );
+    }
+    if (snapshot.aggregateError !== null) {
+      console.log(`Aggregate:    ${snapshot.aggregateError}`);
+    }
+    return EXIT_OK;
+  } catch (error) {
+    return printV3Error(
+      options.json,
+      v3ErrorCode(error, 'MANCODE_V3_WORKFLOW_SHOW_FAILED'),
+      error instanceof Error
+        ? error.message
+        : 'Unable to show the mancode workflow.',
+    );
+  }
+}
+
+function workflowCleanV3(options: WorkflowOptions): number {
+  return printV3Error(
+    options.json,
+    'MANCODE_V3_WORKFLOW_CLEAN_UNSUPPORTED',
+    'V3 workflow authority is durable and is not deleted by workflow clean. Use `mancode context compact --dry-run` to inspect eligible runtime retention records.',
+    EXIT_INVALID_ARG,
+  );
+}
+
+function formatV3WorkflowRow(metadata: WorkflowMetadataV3): string {
+  return [
+    formatTaskRef(metadata.taskRef),
+    metadata.workflowMode,
+    metadata.status,
+    `Step ${metadata.currentStep}/${maxV3WorkflowStep(metadata.workflowMode)}`,
+    `r${metadata.revision}`,
+    metadata.task,
+  ].join('  ');
+}
+
+function maxV3WorkflowStep(mode: WorkflowMetadataV3['workflowMode']): number {
+  return mode === 'manba' ? 5 : 9;
 }
 
 async function workflowUpdateV3(

--- a/src/context/store.ts
+++ b/src/context/store.ts
@@ -336,14 +336,9 @@ export class V3ContextStore {
     };
   }
 
-  /**
-   * Lists non-terminal children from canonical metadata only. Callers that
-   * need a completion gate must hold the parent task lock while invoking it;
-   * V3 child creation takes that same parent lock before publishing.
-   */
-  async listActiveChildTaskRefs(parentTaskRef: TaskRef): Promise<TaskRef[]> {
-    const parent = parseTaskRefValue(parentTaskRef);
-    const children: TaskRef[] = [];
+  /** Lists every canonical V3 workflow without relying on a session pointer. */
+  async listWorkflowMetadata(): Promise<WorkflowMetadataV3[]> {
+    const workflows: WorkflowMetadataV3[] = [];
     for (const namespace of ['local', 'shared'] as const) {
       const directory = path.join('.mancode', namespace, 'workflows');
       const entries = await readDirectoryEntriesWithin(
@@ -352,7 +347,7 @@ export class V3ContextStore {
       );
       for (const taskId of entries.sort(compareUtf8)) {
         try {
-          assertUlid(taskId, 'workflow child directory');
+          assertUlid(taskId, 'workflow directory');
         } catch {
           throw new Error('MANCODE_CONTEXT_COLLECTION_ENTRY_INVALID');
         }
@@ -367,20 +362,40 @@ export class V3ContextStore {
           'metadata.json',
           parseWorkflowMetadata,
         );
-        if (
-          metadata.parent !== null &&
-          sameTaskRef(metadata.parent.taskRef, parent) &&
-          !isTerminalWorkflowStatus(metadata.status)
-        ) {
-          children.push(metadata.taskRef);
+        if (!sameTaskRef(metadata.taskRef, taskRef)) {
+          throw new Error('MANCODE_CONTEXT_TASK_LOCATION_MISMATCH');
         }
+        workflows.push(metadata);
       }
     }
-    return children.sort(
+    return workflows.sort(
       (left, right) =>
-        compareUtf8(left.namespace, right.namespace) ||
-        compareUtf8(left.taskId, right.taskId),
+        Date.parse(right.updatedAt) - Date.parse(left.updatedAt) ||
+        compareUtf8(left.taskRef.namespace, right.taskRef.namespace) ||
+        compareUtf8(left.taskRef.taskId, right.taskRef.taskId),
     );
+  }
+
+  /**
+   * Lists non-terminal children from canonical metadata only. Callers that
+   * need a completion gate must hold the parent task lock while invoking it;
+   * V3 child creation takes that same parent lock before publishing.
+   */
+  async listActiveChildTaskRefs(parentTaskRef: TaskRef): Promise<TaskRef[]> {
+    const parent = parseTaskRefValue(parentTaskRef);
+    return (await this.listWorkflowMetadata())
+      .filter(
+        (metadata) =>
+          metadata.parent !== null &&
+          sameTaskRef(metadata.parent.taskRef, parent) &&
+          !isTerminalWorkflowStatus(metadata.status),
+      )
+      .map((metadata) => metadata.taskRef)
+      .sort(
+        (left, right) =>
+          compareUtf8(left.namespace, right.namespace) ||
+          compareUtf8(left.taskId, right.taskId),
+      );
   }
 
   private mancodeRoot(): string {

--- a/tests/v3-adapter-contracts.test.ts
+++ b/tests/v3-adapter-contracts.test.ts
@@ -73,6 +73,13 @@ describe('V3 adapter bootstrap integration', () => {
       });
       expect(result.activation.managedAdapters.codex).toBe('3');
 
+      logs.mockClear();
+      expect(await status(root, {})).toBe(0);
+      const textOutput = logs.mock.calls.flat().join('\n');
+      expect(textOutput).toContain('Session evidence: explicit required');
+      expect(textOutput).toContain('codex');
+      expect(textOutput).not.toContain('explicit required ()');
+
       expect(await install(root, 'cursor')).toBe(0);
       const cursorRule = await readFile(
         path.join(root, '.cursor', 'rules', 'mancode-v3.mdc'),
@@ -577,6 +584,12 @@ describe('V3 adapter bootstrap integration', () => {
       ).resolves.toContain('v3_active');
       expect(await uninstall(root, undefined, { all: true })).toBe(
         EXIT_V3_AUTHORITY_PROTECTED,
+      );
+      expect(errors.mock.calls.flat().join('\n')).toContain(
+        'context compact --dry-run',
+      );
+      expect(errors.mock.calls.flat().join('\n')).not.toContain(
+        'archive/migration workflow',
       );
     } finally {
       logs.mockRestore();

--- a/tests/v3-command-contracts.test.ts
+++ b/tests/v3-command-contracts.test.ts
@@ -33,6 +33,7 @@ import {
   requirementsLedgerDigest,
 } from '../src/context/requirements-ledger.js';
 import { V3ContextStore } from '../src/context/store.js';
+import type { TaskRef } from '../src/context/task-ref.js';
 import { readSession } from '../src/runtime/session.js';
 import { readLocalActor } from '../src/team/actor.js';
 
@@ -191,6 +192,68 @@ describe('V3 CLI command contracts', () => {
       };
       expect(result.workspaceId).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
       expect(result.checkoutId).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+    } finally {
+      logs.mockRestore();
+      errors.mockRestore();
+    }
+  });
+
+  it('lists and shows V3 workflows without deleting durable authority', async () => {
+    const logs = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(await workflow(root, 'list', [], { json: true })).toBe(0);
+      expect(JSON.parse(String(logs.mock.calls.at(-1)?.[0]))).toMatchObject({
+        schemaVersion: 1,
+        workflows: [],
+      });
+
+      await teamIdentityCreate(root, { name: 'Fixture User', json: true });
+      await contextSessionNew(root, { client: 'fixture', json: true });
+      const sessionId = (
+        JSON.parse(String(logs.mock.calls.at(-1)?.[0])) as {
+          session: { sessionId: string };
+        }
+      ).session.sessionId;
+      await workflow(root, 'create', ['man', 'Discover this V3 task.'], {
+        session: sessionId,
+        client: 'fixture',
+        json: true,
+      });
+      const created = JSON.parse(String(logs.mock.calls.at(-1)?.[0])) as {
+        taskRef: { namespace: string; taskId: string };
+      };
+      const task = `${created.taskRef.namespace}:${created.taskRef.taskId}`;
+
+      expect(await workflow(root, 'list', [], { json: true })).toBe(0);
+      expect(JSON.parse(String(logs.mock.calls.at(-1)?.[0]))).toMatchObject({
+        workflows: [
+          {
+            taskRef: created.taskRef,
+            workflowMode: 'man',
+            status: 'in_progress',
+          },
+        ],
+      });
+      expect(await workflow(root, 'show', [task], { json: true })).toBe(0);
+      expect(JSON.parse(String(logs.mock.calls.at(-1)?.[0]))).toMatchObject({
+        taskRef: created.taskRef,
+        metadata: {
+          task: 'Discover this V3 task.',
+          revision: 1,
+        },
+        activeChildren: [],
+      });
+
+      expect(await workflow(root, 'clean', [], { json: true })).toBe(2);
+      expect(JSON.parse(String(logs.mock.calls.at(-1)?.[0]))).toMatchObject({
+        error: { code: 'MANCODE_V3_WORKFLOW_CLEAN_UNSUPPORTED' },
+      });
+      await expect(
+        new V3ContextStore(root).readTaskSnapshot(created.taskRef as TaskRef),
+      ).resolves.toMatchObject({
+        metadata: { task: 'Discover this V3 task.' },
+      });
     } finally {
       logs.mockRestore();
       errors.mockRestore();

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -8,7 +8,7 @@ describe('version', () => {
     expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
   });
 
-  it('is a stable release without prerelease tag', () => {
+  it('keeps the npm version consumable without a prerelease tag', () => {
     expect(VERSION).not.toMatch(/-(alpha|beta|rc)\./);
   });
 
@@ -21,7 +21,8 @@ describe('version', () => {
 
     for (const readme of readmes) {
       expect(readme).toContain(`v${VERSION}`);
-      expect(readme).toContain(`status-stable%20v${VERSION}`);
+      expect(readme).toContain(`status-V3%20beta%20v${VERSION}`);
+      expect(readme).not.toContain(`status-stable%20v${VERSION}`);
     }
   });
 });

--- a/tests/website-docs.test.ts
+++ b/tests/website-docs.test.ts
@@ -47,8 +47,8 @@ describe('website documentation', () => {
         'refresh-project',
         'manps [area]',
         '--remediate',
-        'require-manual',
-        'confirm-manual',
+        'workflow verify',
+        'workflow review',
         'governed_execution',
         'plan_only',
         'blockingUnknowns',
@@ -71,13 +71,13 @@ describe('website documentation', () => {
     );
   });
 
-  it('shows workflow commands in a legal governed order', async () => {
+  it('shows the V3 workflow command contract', async () => {
     for (const name of ['docs.html', 'docs.zh-CN.html']) {
       const html = await readPage(name);
       const start = html.indexOf(
         name === 'docs.html'
-          ? '<h3>A valid governed sequence</h3>'
-          : '<h3>一条合法的治理式执行顺序</h3>',
+          ? '<h3>A valid V3 sequence</h3>'
+          : '<h3>一条合法的 V3 顺序</h3>',
       );
       const end = html.indexOf(
         name === 'docs.html'
@@ -87,20 +87,15 @@ describe('website documentation', () => {
       );
       const example = html.slice(start, end);
       const orderedTokens = [
-        '--step 2',
-        'requirements &lt;taskId&gt; finalize',
-        '--step 3',
-        '--step 4',
-        'governed_execution',
-        '--step 5',
-        '--step 6',
-        'verify &lt;taskId&gt; init',
-        'verify &lt;taskId&gt; record',
-        'review &lt;taskId&gt; init',
-        '--step 7',
-        'review &lt;taskId&gt; complete',
-        '--step 9',
-        '--status completed',
+        'workflow create man',
+        'workflow list --json',
+        'workflow show &lt;local:ULID&gt; --json',
+        'workflow requirements &lt;local:ULID&gt; finalize',
+        'workflow plan &lt;local:ULID&gt; revise',
+        'workflow plan &lt;local:ULID&gt; confirm',
+        'workflow review &lt;local:ULID&gt; apply',
+        'workflow verify &lt;local:ULID&gt; apply',
+        'workflow complete &lt;local:ULID&gt;',
       ];
 
       let previous = -1;
@@ -111,7 +106,10 @@ describe('website documentation', () => {
         );
         previous = current;
       }
-      expect(example).not.toContain('--step 4 --plan-version 1');
+      expect(example).not.toMatch(/workflow update[^\n]*--step/);
+      expect(example).not.toContain('workflow decide');
+      expect(example).not.toContain('verify &lt;taskId&gt;');
+      expect(example).not.toContain('review &lt;taskId&gt;');
     }
   });
 
@@ -147,8 +145,8 @@ describe('website documentation', () => {
     expect(chinese).toContain('代码，避免');
     expect(chinese).toContain('AI 屎山。');
     expect(chinese).toContain('预览适配器');
-    expect(english).not.toMatch(/\b(?:V3|Beta)\b/);
-    expect(chinese).not.toMatch(/\b(?:V3|Beta)\b/);
+    expect(english).toContain('V3 Beta / v0.3.13');
+    expect(chinese).toContain('V3 Beta / v0.3.13');
   });
 
   it('documents the cross-session boundary in both languages', async () => {

--- a/website/docs.html
+++ b/website/docs.html
@@ -98,10 +98,10 @@
           <h2>Files &amp; privacy</h2>
           <p>mancode works locally, scans only the current project, and sends no telemetry. It deliberately does not rewrite your project's <code>.gitignore</code>, so your team—not the installer—decides which generated context belongs in version control.</p>
           <table class="docs-table artifact-table"><thead><tr><th>Path</th><th>What it contains</th><th>Before committing</th></tr></thead><tbody>
-            <tr><td><code>.mancode/config.json</code><br /><code>.mancode/state.json</code></td><td>Selected adapters, current mode, and active workflow pointers.</td><td>Review as project configuration; share only when the team wants the same setup.</td></tr>
-            <tr><td><code>.mancode/project-profile.json</code><br /><code>style-tokens.json</code></td><td>Detected stack, validation commands, and UI tokens.</td><td>Inspect for internal project details and decide whether reproducibility justifies sharing.</td></tr>
-            <tr><td><code>.mancode/workflows/</code></td><td>Requirements, plans, review scope, verification evidence, reports, and summaries.</td><td>Review carefully. Evidence, logs, screenshots, traces, and browser artifacts may contain sensitive data and are often better ignored or sanitized.</td></tr>
-            <tr><td><code>.mancode/memory/</code></td><td>Team decisions and durable shared context.</td><td>Commit only information intentionally written for the team.</td></tr>
+            <tr><td><code>.mancode/schema.json</code><br /><code>.mancode/shared/</code><br /><code>.mancode/local/</code></td><td>V3 authority, project policy, sessions, workflow metadata, and local runtime records. Legacy <code>state.json</code> exists only after explicit <code>--legacy</code> initialization.</td><td>Review workflow evidence and local records before sharing; raw host session keys are never persisted.</td></tr>
+            <tr><td><code>.mancode/shared/context/project.json</code><br /><code>.mancode/local/cache/style-tokens.json</code></td><td>Detected stack, validation commands, and local UI tokens.</td><td>Inspect for internal project details and decide whether reproducibility justifies sharing.</td></tr>
+            <tr><td><code>.mancode/local/workflows/</code><br /><code>.mancode/shared/workflows/</code></td><td>Requirements, plans, review and verification ledgers, reports, checkpoints, and summaries.</td><td>Review carefully. Evidence and reports may contain sensitive data; shared workflows pass the V3 privacy boundary.</td></tr>
+            <tr><td><code>.mancode/shared/context/decisions/</code><br /><code>.mancode/shared/team/</code></td><td>Confirmed decisions and durable coordination authority.</td><td>Commit only information intentionally written for the team.</td></tr>
             <tr><td><code>.claude/</code>, <code>.cursor/</code>, <code>.agents/</code>, <code>.github/</code>, <code>AGENTS.md</code></td><td>Adapter instructions, commands or prompts, skills, hooks, and managed blocks.</td><td>Share when the adapter is part of the team's development workflow. Content outside mancode's managed blocks remains yours.</td></tr>
           </tbody></table>
           <div class="docs-note"><strong>Safety boundary</strong><p><code>mancode manps</code> scans and reports by default. Remediation is explicit. Irreversible project operations still require human confirmation; installing mancode does not grant the agent permission to publish, delete, or rewrite unrelated work.</p></div>
@@ -171,19 +171,19 @@ $manteam</code></pre><button type="button" data-copy-code>Copy</button></div></a
             <article class="command-card"><header><h3>mancode install [platform]</h3><span>Adapter</span></header><p>Installs or repairs an adapter after initialization. Omit the platform for interactive selection.</p><ul><li><code>--force</code> regenerates managed content.</li><li><code>--minimal</code> installs solo-mode essentials only.</li></ul></article>
             <article class="command-card"><header><h3>mancode status [--json]</h3><span>Inspect</span></header><p>Reports project facts, current mode and workflow, adapter readiness, and Claude hook registration where applicable.</p></article>
             <article class="command-card"><header><h3>mancode list-platforms</h3><span>Discover</span></header><p>Lists adapters known to the installed CLI and marks those already configured in the project.</p></article>
-            <article class="command-card"><header><h3>mancode workflow &lt;subcommand&gt;</h3><span>Govern</span></header><p>Creates and validates requirements, plans, verification evidence, reviews, remediation, and completion. See the detailed lifecycle below.</p><ul><li>Inspect with <code>list</code> and <code>show &lt;taskId&gt; [--json]</code>.</li><li>Prune old completed records with <code>clean --older-than &lt;duration&gt; [--dry-run]</code>.</li></ul></article>
+            <article class="command-card"><header><h3>mancode workflow &lt;subcommand&gt;</h3><span>Govern</span></header><p>Creates and validates V3 requirements, plans, verification evidence, reviews, remediation, and completion.</p><ul><li>Inspect with <code>list</code> and <code>show &lt;namespace:ULID&gt; [--json]</code>.</li><li>Use <code>context compact --dry-run</code> to inspect removable runtime records; V3 workflow authority is not deleted by <code>workflow clean</code>.</li></ul></article>
             <article class="command-card"><header><h3>mancode manps [area]</h3><span>Scan</span></header><p>Runs a deterministic health scan for <code>all</code>, <code>deps</code>, <code>security</code>, <code>dead-code</code>, <code>config</code>.</p><ul><li><code>--json</code> emits machine-readable output.</li><li><code>--remediate</code> enters the explicit remediation path; the default is scan-only.</li></ul></article>
             <article class="command-card"><header><h3>mancode refresh-project</h3><span>Rescan</span></header><p>Refreshes project facts after adding Git, a manifest, a framework, or validation commands, then updates installed static adapters.</p></article>
             <article class="command-card"><header><h3>mancode refresh-style</h3><span>Design</span></header><p>Refreshes the project profile and design tokens. Reinstall static adapters with <code>--force</code> afterward.</p></article>
-            <article class="command-card"><header><h3>mancode uninstall [platform]</h3><span>Remove</span></header><p>Removes one adapter, or all mancode project artifacts with <code>--all</code>. Use <code>--force</code> for non-interactive confirmation.</p></article>
+            <article class="command-card"><header><h3>mancode uninstall [platform]</h3><span>Remove</span></header><p>Removes one V3 adapter. V3 protects authority from bulk removal; use <code>context compact --dry-run</code> for retention candidates. The <code>--all</code> form is legacy-only.</p></article>
             <article class="command-card"><header><h3>mancode version</h3><span>Version</span></header><p>Prints the installed CLI version for upgrade checks and issue reports.</p></article>
           </div>
         </section>
 
         <section class="doc-section" id="workflow" data-searchable>
           <h2>Study the /man workflow</h2>
-          <p><code>/man</code> is a progressive nine-step protocol. It first makes the decision inspectable, then lets the user choose between a lightweight handoff, a plan-only result, or governed execution. Every gate is backed by files under <code>.mancode/workflows/&lt;taskId&gt;/</code>.</p>
-          <div class="docs-note"><strong>Who runs these commands?</strong><p>The installed <code>man</code> skill creates the task, stores its active pointer in <code>.mancode/state.json</code>, writes artifacts, and calls the CLI. The commands below are the machine contract for studying, debugging, or integrating the process. A standalone <code>workflow create</code> does not activate the task pointer by itself.</p></div>
+          <p><code>/man</code> is a progressive nine-step protocol. It first makes the decision inspectable, then lets the user choose between a lightweight handoff, a plan-only result, or governed execution. Every gate is backed by V3 files under <code>.mancode/&lt;namespace&gt;/workflows/&lt;ULID&gt;/</code>.</p>
+          <div class="docs-note"><strong>Who runs these commands?</strong><p>The installed V3 mode entry creates the task and reads its Context Pack. The commands below are the machine contract for studying, debugging, or integrating the process. V3 identifies tasks with explicit <code>namespace:ULID</code> TaskRefs and does not use a legacy active pointer.</p></div>
 
           <h3>The nine steps and their gates</h3>
           <table class="docs-table workflow-table"><thead><tr><th>Step</th><th>Agent work</th><th>Durable gate</th></tr></thead><tbody>
@@ -226,78 +226,61 @@ $manteam</code></pre><button type="button" data-copy-code>Copy</button></div></a
     }
   ]
 }</code></pre><button type="button" data-copy-code>Copy</button></div>
-          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow requirements &lt;taskId&gt; finalize --file requirements-input.json</code></pre><button type="button" data-copy-code>Copy</button></div>
+          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow requirements &lt;local:ULID&gt; finalize --file requirements-input.json --expected-revision &lt;revision&gt; --session &lt;session-id&gt;</code></pre><button type="button" data-copy-code>Copy</button></div>
           <p>A successful result says <code>ready</code>. A result of <code>needs_clarification</code> is a hard stop: resolve <code>blockingUnknowns</code>, regenerate the input, and finalize again.</p>
 
           <h3>The Step 4 decision</h3>
           <div class="decision-grid">
-            <article class="command-card"><header><h3>Solo handoff</h3><span>Deliver</span></header><p>Use when the plan is settled but implementation risk is routine.</p><div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow handoff &lt;taskId&gt; --to solo
+            <article class="command-card"><header><h3>Solo handoff</h3><span>Deliver</span></header><p>Use when the plan is settled but implementation risk is routine.</p><div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow handoff &lt;local:ULID&gt; --to solo --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
 <span class="command-prompt"># after solo implements and verifies</span>
-<span class="command-prompt">$</span> mancode workflow handoff &lt;taskId&gt; --complete</code></pre><button type="button" data-copy-code>Copy</button></div></article>
-            <article class="command-card"><header><h3>Governed execution</h3><span>Continue</span></header><p>Use when implementation, evidence, and independent review should remain inside the nine-step record.</p><div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow decide &lt;taskId&gt; --plan-decision governed_execution</code></pre><button type="button" data-copy-code>Copy</button></div></article>
-            <article class="command-card"><header><h3>Plan only</h3><span>Stop</span></header><p>Use when the requested deliverable is the confirmed plan, not code.</p><div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow decide &lt;taskId&gt; --plan-decision plan_only</code></pre><button type="button" data-copy-code>Copy</button></div></article>
+<span class="command-prompt">$</span> mancode workflow handoff &lt;local:ULID&gt; --complete --expected-revision &lt;revision&gt; --session &lt;session-id&gt;</code></pre><button type="button" data-copy-code>Copy</button></div></article>
+            <article class="command-card"><header><h3>Governed execution</h3><span>Continue</span></header><p>Use when implementation, evidence, and independent review should remain inside the nine-step record.</p><div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow plan &lt;local:ULID&gt; confirm --plan-decision governed_execution --expected-revision &lt;revision&gt; --session &lt;session-id&gt;</code></pre><button type="button" data-copy-code>Copy</button></div></article>
+            <article class="command-card"><header><h3>Plan only</h3><span>Stop</span></header><p>Use when the requested deliverable is the confirmed plan, not code.</p><div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow plan &lt;local:ULID&gt; confirm --plan-decision plan_only --expected-revision &lt;revision&gt; --session &lt;session-id&gt;</code></pre><button type="button" data-copy-code>Copy</button></div></article>
           </div>
-          <p>All three choices require an active in-progress <code>man</code> workflow at Step 4, ready requirements, and <code>plan.md</code>. Revision stays at the plan gate, updates the file, and increments <code>--plan-version</code> from the initial v1 to v2, then v3, and so on.</p>
+          <p>All three choices require an active <code>man</code> workflow, confirmed requirements, and <code>plan.md</code>. Revise the plan with <code>workflow plan ... revise</code>; every successful mutation returns the revision required by the next command.</p>
 
-          <h3>A valid governed sequence</h3>
-          <p>This condensed trace shows legal ordering. Comments mark files written by the agent; they are not shell commands. The agent advances each numbered step only after its work and artifact are complete.</p>
-          <div class="code-wrap"><pre><code><span class="command-prompt"># Step 1–2: create, scout, clarify, and freeze requirements</span>
-<span class="command-prompt">$</span> mancode workflow create man "refactor auth module" --json
-<span class="command-prompt"># agent stores taskId as the active workflow and writes scout-report.md</span>
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 2
-<span class="command-prompt">$</span> mancode workflow requirements &lt;taskId&gt; finalize --file requirements-input.json
+          <h3>A valid V3 sequence</h3>
+          <p>V3 uses explicit TaskRefs and expected revisions. The CLI owns every durable mutation; do not edit metadata files or use the legacy <code>--step</code> protocol.</p>
+          <div class="code-wrap"><pre><code><span class="command-prompt"># Bootstrap an actor and explicit session</span>
+<span class="command-prompt">$</span> mancode team identity create --name "Your name"
+<span class="command-prompt">$</span> mancode context session new --client codex --json
 
-<span class="command-prompt"># Step 3–4: write plan.md and reach the user decision gate</span>
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 3
-<span class="command-prompt"># agent writes plan.md</span>
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 4
-<span class="command-prompt">$</span> mancode workflow decide &lt;taskId&gt; --plan-decision governed_execution
+<span class="command-prompt"># Create, discover, and inspect a task</span>
+<span class="command-prompt">$</span> mancode workflow create man "refactor auth module" --session &lt;session-id&gt; --json
+<span class="command-prompt">$</span> mancode workflow list --json
+<span class="command-prompt">$</span> mancode workflow show &lt;local:ULID&gt; --json
 
-<span class="command-prompt"># Step 5–6: implement, initialize verification, and record every required AC</span>
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 5
-<span class="command-prompt"># agent implements the confirmed plan</span>
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 6
-<span class="command-prompt">$</span> mancode workflow verify &lt;taskId&gt; init
-<span class="command-prompt">$</span> mancode workflow verify &lt;taskId&gt; record --acceptance AC-LOGIN --method automated --result passed --evidence "auth tests passed" --command "npm test -- auth" --exit-code 0
+<span class="command-prompt"># Requirements and plan gates (use the revision returned by each command)</span>
+<span class="command-prompt">$</span> mancode workflow requirements &lt;local:ULID&gt; finalize --file requirements-input.json --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
+<span class="command-prompt">$</span> mancode workflow plan &lt;local:ULID&gt; revise --file plan.md --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
+<span class="command-prompt">$</span> mancode workflow plan &lt;local:ULID&gt; confirm --plan-decision governed_execution --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
 
-<span class="command-prompt"># Step 7–9: targeted review, report, summary, completion</span>
-<span class="command-prompt"># agent writes review-scope.md</span>
-<span class="command-prompt">$</span> mancode workflow review &lt;taskId&gt; init --review-depth targeted --review-domain quality
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 7
-<span class="command-prompt"># agent writes film-report-1.md</span>
-<span class="command-prompt">$</span> mancode workflow review &lt;taskId&gt; complete --review-domain quality --report film-report-1.md
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 9
-<span class="command-prompt"># agent writes summary.md</span>
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --status completed</code></pre><button type="button" data-copy-code>Copy</button></div>
+<span class="command-prompt"># Record canonical review and verification ledgers</span>
+<span class="command-prompt">$</span> mancode workflow review &lt;local:ULID&gt; apply --file review-ledger.json --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
+<span class="command-prompt">$</span> mancode workflow verify &lt;local:ULID&gt; apply --file verification-ledger.json --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
+<span class="command-prompt">$</span> mancode workflow complete &lt;local:ULID&gt; --expected-revision &lt;revision&gt; --session &lt;session-id&gt;</code></pre><button type="button" data-copy-code>Copy</button></div>
 
           <h3>Verification, manual checks, and remediation</h3>
           <table class="docs-table"><thead><tr><th>Case</th><th>Required record</th><th>Gate behavior</th></tr></thead><tbody>
-            <tr><td>Automated</td><td><code>record</code> with acceptance ID, method, result, evidence, exact command, and exit code. A passing result requires exit code 0; a failure requires non-zero.</td><td>Step 7 and review stay blocked until every required acceptance criterion passes.</td></tr>
-            <tr><td>Manual</td><td><code>require-manual</code> explains why automation cannot decide. Only after the user performs the check may the agent call <code>confirm-manual</code> with observed evidence.</td><td>The workflow is blocked while confirmation is pending.</td></tr>
-            <tr><td>Review finding</td><td><code>review complete ... --blockers Q1,Q2</code> stores stable IDs. Fix once with <code>review remediate --resolved Q1,Q2</code>.</td><td>Remediation invalidates earlier verification; all required criteria must be re-run and re-recorded at Step 9.</td></tr>
-            <tr><td>User skips review</td><td><code>review skip --reason "explicit user request"</code> at Step 6 after verification.</td><td>The reason is durable, but <code>summary.md</code> and Step 9 completion are still required.</td></tr>
+            <tr><td>Automated</td><td>The canonical verification ledger records the criterion, command, exit code, evidence summary, and result.</td><td><code>workflow verify ... apply</code> rejects a ledger that does not satisfy the V3 schema and current revision.</td></tr>
+            <tr><td>Manual</td><td>The ledger records why automation cannot decide and only changes to passed after explicit user confirmation.</td><td>Completion remains blocked while required manual evidence is pending.</td></tr>
+            <tr><td>Review finding</td><td>The canonical review ledger stores stable blocker IDs and their remediation state.</td><td>Applying a review ledger makes earlier verification stale; apply current verification after review and before completion.</td></tr>
+            <tr><td>User skips review</td><td>The review ledger records the explicit user decision and residual risk.</td><td>Completion still requires a valid summary and every remaining gate.</td></tr>
           </tbody></table>
-          <div class="code-wrap"><pre><code><span class="command-prompt"># manual acceptance: stop and wait after require-manual</span>
-<span class="command-prompt">$</span> mancode workflow verify &lt;taskId&gt; require-manual --acceptance AC-UI --evidence "foreground browser judgment required"
-<span class="command-prompt"># only after explicit user confirmation</span>
-<span class="command-prompt">$</span> mancode workflow verify &lt;taskId&gt; confirm-manual --acceptance AC-UI --evidence "user confirmed the interaction"
-
-<span class="command-prompt"># one blocker-remediation round</span>
-<span class="command-prompt">$</span> mancode workflow review &lt;taskId&gt; complete --review-domain quality --report film-report-1.md --blockers Q1
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 9
-<span class="command-prompt">$</span> mancode workflow review &lt;taskId&gt; remediate --resolved Q1
-<span class="command-prompt">$</span> mancode workflow verify &lt;taskId&gt; record --acceptance AC-LOGIN --method automated --result passed --evidence "post-fix tests passed" --command "npm test -- auth" --exit-code 0</code></pre><button type="button" data-copy-code>Copy</button></div>
+          <div class="code-wrap"><pre><code><span class="command-prompt"># Update the canonical ledgers after a remediation</span>
+<span class="command-prompt">$</span> mancode workflow review &lt;local:ULID&gt; apply --file review-ledger.json --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
+<span class="command-prompt">$</span> mancode workflow verify &lt;local:ULID&gt; apply --file verification-ledger.json --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
+<span class="command-prompt">$</span> mancode workflow complete &lt;local:ULID&gt; --expected-revision &lt;revision&gt; --session &lt;session-id&gt;</code></pre><button type="button" data-copy-code>Copy</button></div>
 
           <h3>Workflow subcommands</h3>
           <table class="docs-table"><thead><tr><th>Command</th><th>Purpose</th><th>Important options</th></tr></thead><tbody>
-            <tr><td><code>create</code></td><td>Start a <code>man</code>, <code>manba</code>, or <code>manteam</code> record.</td><td><code>--parent-task</code> links a diagnostic child; <code>--json</code> exposes the task ID.</td></tr>
-            <tr><td><code>requirements</code></td><td>Finalize the Step 2 ledger from JSON.</td><td><code>finalize --file</code>.</td></tr>
-            <tr><td><code>update</code></td><td>Advance step, status, plan version, or durable outcome.</td><td><code>--step</code>, <code>--status</code>, <code>--plan-version</code>, <code>--blocking-reason</code>, <code>--outcome</code>. Only clarification may use generic <code>--skipped</code>.</td></tr>
-            <tr><td><code>decide</code></td><td>Resolve the Step 4 plan gate.</td><td><code>--plan-decision governed_execution|plan_only</code>.</td></tr>
-            <tr><td><code>handoff</code></td><td>Transfer a confirmed plan to solo and later close it.</td><td><code>--to solo</code>, then <code>--complete</code>.</td></tr>
-            <tr><td><code>verify</code></td><td>Initialize and record acceptance evidence.</td><td><code>init</code>, <code>record</code>, <code>require-manual</code>, <code>confirm-manual</code>; evidence options include <code>--command</code>, <code>--exit-code</code>, and <code>--evidence-file</code>.</td></tr>
-            <tr><td><code>review</code></td><td>Initialize targeted/full review, store reports and blockers, remediate once, or record an explicit skip.</td><td><code>--review-depth</code>, <code>--review-domain</code>, <code>--report</code>, <code>--blockers</code>, <code>--resolved</code>, <code>--reason</code>.</td></tr>
-            <tr><td><code>list / show / clean</code></td><td>Inspect records or remove old completed records.</td><td><code>show --json</code>; <code>clean --older-than 30d --dry-run</code>.</td></tr>
+            <tr><td><code>create</code></td><td>Start a <code>man</code>, <code>manba</code>, or <code>manteam</code> record.</td><td><code>--parent &lt;TaskRef&gt;</code> links a diagnostic child; <code>--json</code> exposes the TaskRef.</td></tr>
+            <tr><td><code>requirements</code></td><td>Finalize the structured requirements ledger.</td><td><code>finalize --file --expected-revision --session</code>.</td></tr>
+            <tr><td><code>plan</code></td><td>Revise a plan or confirm its execution decision.</td><td><code>revise --file</code>; <code>confirm --plan-decision</code>; both require revision and session.</td></tr>
+            <tr><td><code>update</code></td><td>Change lifecycle status or a blocking reason.</td><td><code>--status --expected-revision --session</code>; governed fields use dedicated commands.</td></tr>
+            <tr><td><code>handoff</code></td><td>Transfer a confirmed local plan to solo and later close it.</td><td><code>--to solo</code> or <code>--complete</code>, with revision and session.</td></tr>
+            <tr><td><code>verify / review</code></td><td>Apply canonical V3 ledgers.</td><td><code>apply --file --expected-revision --session</code>.</td></tr>
+            <tr><td><code>list / show / clean</code></td><td>List or inspect V3 TaskRefs. <code>clean</code> is not a V3 authority deletion command.</td><td><code>show &lt;namespace:ULID&gt; --json</code>; use <code>context compact --dry-run</code> for retention.</td></tr>
           </tbody></table>
         </section>
 
@@ -324,16 +307,14 @@ $manteam</code></pre><button type="button" data-copy-code>Copy</button></div></a
 
         <section class="doc-section" id="uninstall" data-searchable>
           <h2>Uninstall safely</h2>
-          <p>Uninstall preserves user-authored rules, instructions, and unrelated Claude settings. Review workflow records before deletion if they contain decisions or evidence you still need.</p>
+          <p>Uninstalling one adapter preserves user-authored rules, instructions, unrelated Claude settings, and V3 workflow authority. Use <code>context compact --dry-run</code> to inspect eligible runtime retention records.</p>
           <h3>Remove one adapter</h3>
           <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode uninstall cursor --force</code></pre><button type="button" data-copy-code>Copy</button></div>
-          <h3>Clean reinstall</h3>
-          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode uninstall --all --force
-<span class="command-prompt">$</span> mancode init
-<span class="command-prompt">$</span> mancode install &lt;platform&gt;</code></pre><button type="button" data-copy-code>Copy</button></div>
-          <h3>Remove mancode completely</h3>
-          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode uninstall --all --force
-<span class="command-prompt">$</span> npm uninstall -g mancode</code></pre><button type="button" data-copy-code>Copy</button></div>
+          <h3>Reinstall one adapter</h3>
+          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode uninstall claude-code --force
+<span class="command-prompt">$</span> mancode install claude-code</code></pre><button type="button" data-copy-code>Copy</button></div>
+          <h3>Remove the CLI</h3>
+          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> npm uninstall -g mancode</code></pre><button type="button" data-copy-code>Copy</button></div>
         </section>
 
         <section class="doc-section" id="troubleshooting" data-searchable>
@@ -347,7 +328,7 @@ $manteam</code></pre><button type="button" data-copy-code>Copy</button></div></a
           <h3>Cursor rules do not trigger</h3>
           <p>Confirm that <code>.cursor/rules/mancode-*.mdc</code> and <code>.cursor/commands/*.md</code> exist. Core context and solo rules are persistent; higher-intensity rules are description-triggered, so invoke the generated mode command explicitly.</p>
           <h3>A workflow command is rejected</h3>
-          <p>Treat the rejection as a gate, not a file-corruption problem. Use <code>mancode workflow show &lt;taskId&gt; --json</code> to inspect the step, requirements readiness, plan decision, verification, review domains, and blockers. Do not edit <code>metadata.json</code> manually.</p>
+          <p>Treat the rejection as a gate, not a file-corruption problem. Use <code>mancode workflow list --json</code> to discover TaskRefs, then <code>mancode workflow show &lt;namespace:ULID&gt; --json</code> to inspect metadata, revision, aggregate, and blockers. Do not edit V3 metadata manually.</p>
           <h3>Project facts became stale</h3>
           <p>After adding Git, a manifest, dependencies, or validation scripts, run <code>mancode refresh-project</code>. Use <code>refresh-style</code> for UI tokens. Then repair a static adapter only if its generated files need regeneration.</p>
         </section>

--- a/website/docs.zh-CN.html
+++ b/website/docs.zh-CN.html
@@ -98,10 +98,10 @@
           <h2>文件与隐私</h2>
           <p>mancode 本地运行，只扫描当前项目，不发送遥测。它不会擅自改写项目的 <code>.gitignore</code>，因此哪些生成上下文应该进入版本控制，需要由你的团队明确决定。</p>
           <table class="docs-table artifact-table"><thead><tr><th>路径</th><th>包含什么</th><th>提交前怎么处理</th></tr></thead><tbody>
-            <tr><td><code>.mancode/config.json</code><br /><code>.mancode/state.json</code></td><td>所选平台、当前模式和活动工作流指针。</td><td>把它当作项目配置检查；只有团队希望共享同一套设置时才提交。</td></tr>
-            <tr><td><code>.mancode/project-profile.json</code><br /><code>style-tokens.json</code></td><td>识别出的技术栈、验证命令和 UI token。</td><td>检查是否带有内部项目信息，再权衡复现能力与暴露范围。</td></tr>
-            <tr><td><code>.mancode/workflows/</code></td><td>需求、计划、评审范围、验证证据、报告与总结。</td><td>重点检查。日志、截图、trace 和浏览器产物可能含敏感数据，通常应忽略、脱敏或只保留必要摘要。</td></tr>
-            <tr><td><code>.mancode/memory/</code></td><td>团队决策与长期共享上下文。</td><td>只提交有意写给团队的内容。</td></tr>
+            <tr><td><code>.mancode/schema.json</code><br /><code>.mancode/shared/</code><br /><code>.mancode/local/</code></td><td>V3 权威、项目策略、会话、工作流元数据和本地运行时记录。只有显式使用 <code>--legacy</code> 初始化后才会出现旧 <code>state.json</code>。</td><td>共享前检查工作流证据和本地记录；原始宿主 session key 不会持久化。</td></tr>
+            <tr><td><code>.mancode/shared/context/project.json</code><br /><code>.mancode/local/cache/style-tokens.json</code></td><td>识别出的技术栈、验证命令和本地 UI token。</td><td>检查是否带有内部项目信息，再权衡复现能力与暴露范围。</td></tr>
+            <tr><td><code>.mancode/local/workflows/</code><br /><code>.mancode/shared/workflows/</code></td><td>需求、计划、评审和验证台账、报告、checkpoint 与总结。</td><td>重点检查。证据和报告可能含敏感数据；shared workflow 必须通过 V3 隐私边界。</td></tr>
+            <tr><td><code>.mancode/shared/context/decisions/</code><br /><code>.mancode/shared/team/</code></td><td>已确认决策与持久化协调权威。</td><td>只提交有意写给团队的内容。</td></tr>
             <tr><td><code>.claude/</code>、<code>.cursor/</code>、<code>.agents/</code>、<code>.github/</code>、<code>AGENTS.md</code></td><td>平台 instructions、命令或 prompt、skills、hooks 与受控区块。</td><td>团队确实把该适配器作为开发流程的一部分时再共享；mancode 管理标记之外的内容仍归用户所有。</td></tr>
           </tbody></table>
           <div class="docs-note"><strong>安全边界</strong><p><code>mancode manps</code> 默认只扫描和报告，修复必须显式进入 remediation 路径。安装 mancode 也不会赋予 Agent 发布、删除或重写无关工作的权限；不可逆操作仍需人工确认。</p></div>
@@ -171,19 +171,19 @@ $manteam</code></pre><button type="button" data-copy-code>复制</button></div><
             <article class="command-card"><header><h3>mancode install [platform]</h3><span>适配器</span></header><p>初始化后安装或修复一个平台。省略平台名时进入交互选择。</p><ul><li><code>--force</code> 重新生成受控内容。</li><li><code>--minimal</code> 只安装 solo 的必要内容。</li></ul></article>
             <article class="command-card"><header><h3>mancode status [--json]</h3><span>检查</span></header><p>报告项目事实、当前模式和工作流、平台就绪状态，以及适用时的 Claude hook 注册情况。</p></article>
             <article class="command-card"><header><h3>mancode list-platforms</h3><span>发现</span></header><p>列出当前 CLI 支持的平台，并标出项目中已经配置的平台。</p></article>
-            <article class="command-card"><header><h3>mancode workflow &lt;subcommand&gt;</h3><span>治理</span></header><p>创建和校验需求、计划、验证证据、评审、修复与完成状态。完整生命周期见下一节。</p><ul><li>使用 <code>list</code> 和 <code>show &lt;taskId&gt; [--json]</code> 检查。</li><li>使用 <code>clean --older-than &lt;duration&gt; [--dry-run]</code> 清理较早的已完成记录。</li></ul></article>
+            <article class="command-card"><header><h3>mancode workflow &lt;subcommand&gt;</h3><span>治理</span></header><p>创建和校验 V3 需求、计划、验证证据、评审、修复与完成状态。</p><ul><li>使用 <code>list</code> 和 <code>show &lt;namespace:ULID&gt; [--json]</code> 检查。</li><li>使用 <code>context compact --dry-run</code> 检查可回收的运行时记录；V3 workflow authority 不会被 <code>workflow clean</code> 删除。</li></ul></article>
             <article class="command-card"><header><h3>mancode manps [area]</h3><span>扫描</span></header><p>对 <code>all</code>、<code>deps</code>、<code>security</code>、<code>dead-code</code> 或 <code>config</code> 执行确定性健康扫描。</p><ul><li><code>--json</code> 输出机器可读结果。</li><li><code>--remediate</code> 显式进入修复路径；默认只扫描。</li></ul></article>
             <article class="command-card"><header><h3>mancode refresh-project</h3><span>重扫项目</span></header><p>在加入 Git、manifest、框架或验证命令后刷新项目事实，并更新已安装的静态适配器。</p></article>
             <article class="command-card"><header><h3>mancode refresh-style</h3><span>设计上下文</span></header><p>刷新项目画像和设计 token，之后可用 <code>--force</code> 重装需要更新的静态适配器。</p></article>
-            <article class="command-card"><header><h3>mancode uninstall [platform]</h3><span>移除</span></header><p>移除一个平台；使用 <code>--all</code> 清理项目内全部 mancode 产物，<code>--force</code> 用于非交互确认。</p></article>
+            <article class="command-card"><header><h3>mancode uninstall [platform]</h3><span>移除</span></header><p>移除一个 V3 适配器。V3 会保护权威数据不被批量删除；用 <code>context compact --dry-run</code> 检查保留候选。<code>--all</code> 只适用于 legacy 项目。</p></article>
             <article class="command-card"><header><h3>mancode version</h3><span>版本</span></header><p>输出已安装 CLI 版本，便于升级检查和提交问题。</p></article>
           </div>
         </section>
 
         <section class="doc-section" id="workflow" data-searchable>
           <h2>深入研究 /man 工作流</h2>
-          <p><code>/man</code> 是一个渐进式九步协议：先让决策变得可检查，再由用户选择轻量交接、仅保留计划，或继续治理式执行。每个闸门都由 <code>.mancode/workflows/&lt;taskId&gt;/</code> 下的文件支撑。</p>
-          <div class="docs-note"><strong>谁来运行这些命令？</strong><p>安装后的 <code>man</code> skill 会创建任务、把活动指针写入 <code>.mancode/state.json</code>、生成产物，并调用 CLI。下面展示的是供研究、排错或集成使用的机器契约。单独执行一次 <code>workflow create</code> 并不会自动激活该任务指针。</p></div>
+          <p><code>/man</code> 是一个渐进式九步协议：先让决策变得可检查，再由用户选择轻量交接、仅保留计划，或继续治理式执行。每个闸门都由 V3 的 <code>.mancode/&lt;namespace&gt;/workflows/&lt;ULID&gt;/</code> 文件支撑。</p>
+          <div class="docs-note"><strong>谁来运行这些命令？</strong><p>安装后的 V3 mode entry 会创建任务并读取 Context Pack。下面展示的是供研究、排错或集成使用的机器契约。V3 使用显式 <code>namespace:ULID</code> TaskRef，不依赖旧的活动指针。</p></div>
 
           <h3>九个步骤与闸门</h3>
           <table class="docs-table workflow-table"><thead><tr><th>步骤</th><th>Agent 工作</th><th>持久化闸门</th></tr></thead><tbody>
@@ -226,78 +226,61 @@ $manteam</code></pre><button type="button" data-copy-code>复制</button></div><
     }
   ]
 }</code></pre><button type="button" data-copy-code>复制</button></div>
-          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow requirements &lt;taskId&gt; finalize --file requirements-input.json</code></pre><button type="button" data-copy-code>复制</button></div>
+          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow requirements &lt;local:ULID&gt; finalize --file requirements-input.json --expected-revision &lt;revision&gt; --session &lt;session-id&gt;</code></pre><button type="button" data-copy-code>复制</button></div>
           <p>成功结果会显示 <code>ready</code>。如果结果是 <code>needs_clarification</code>，必须停止推进，先解决 <code>blockingUnknowns</code>，重新生成输入后再次 finalize。</p>
 
           <h3>Step 4 的三种决策</h3>
           <div class="decision-grid">
-            <article class="command-card"><header><h3>交给 solo</h3><span>实施</span></header><p>计划已经稳定，但实现风险属于日常范围。</p><div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow handoff &lt;taskId&gt; --to solo
+            <article class="command-card"><header><h3>交给 solo</h3><span>实施</span></header><p>计划已经稳定，但实现风险属于日常范围。</p><div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow handoff &lt;local:ULID&gt; --to solo --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
 <span class="command-prompt"># solo 实现并验证后</span>
-<span class="command-prompt">$</span> mancode workflow handoff &lt;taskId&gt; --complete</code></pre><button type="button" data-copy-code>复制</button></div></article>
-            <article class="command-card"><header><h3>治理式执行</h3><span>继续</span></header><p>实现、证据和独立评审都需要保留在九步记录内。</p><div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow decide &lt;taskId&gt; --plan-decision governed_execution</code></pre><button type="button" data-copy-code>复制</button></div></article>
-            <article class="command-card"><header><h3>只保留计划</h3><span>停止</span></header><p>用户需要的交付物是计划，而不是代码。</p><div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow decide &lt;taskId&gt; --plan-decision plan_only</code></pre><button type="button" data-copy-code>复制</button></div></article>
+<span class="command-prompt">$</span> mancode workflow handoff &lt;local:ULID&gt; --complete --expected-revision &lt;revision&gt; --session &lt;session-id&gt;</code></pre><button type="button" data-copy-code>复制</button></div></article>
+            <article class="command-card"><header><h3>治理式执行</h3><span>继续</span></header><p>实现、证据和独立评审都需要保留在九步记录内。</p><div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow plan &lt;local:ULID&gt; confirm --plan-decision governed_execution --expected-revision &lt;revision&gt; --session &lt;session-id&gt;</code></pre><button type="button" data-copy-code>复制</button></div></article>
+            <article class="command-card"><header><h3>只保留计划</h3><span>停止</span></header><p>用户需要的交付物是计划，而不是代码。</p><div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode workflow plan &lt;local:ULID&gt; confirm --plan-decision plan_only --expected-revision &lt;revision&gt; --session &lt;session-id&gt;</code></pre><button type="button" data-copy-code>复制</button></div></article>
           </div>
-          <p>三种选择都要求：活动中的 <code>man</code> 工作流位于 Step 4、需求已 ready，并且 <code>plan.md</code> 存在。选择修订时仍停留在计划闸门，更新文件，并用 <code>--plan-version</code> 从初始 v1 递增到 v2、v3。</p>
+          <p>三种选择都要求活动中的 <code>man</code> 工作流、已确认需求和 <code>plan.md</code>。使用 <code>workflow plan ... revise</code> 修订计划；每次成功写入都会返回下一个命令需要的 revision。</p>
 
-          <h3>一条合法的治理式执行顺序</h3>
-          <p>下面是压缩后的有效顺序。注释表示由 Agent 写入的文件，不是终端命令；只有当前阶段的工作和产物都完成后，Agent 才推进编号步骤。</p>
-          <div class="code-wrap"><pre><code><span class="command-prompt"># Step 1–2：创建、侦察、澄清并冻结需求</span>
-<span class="command-prompt">$</span> mancode workflow create man "refactor auth module" --json
-<span class="command-prompt"># Agent 保存活动 taskId，并写入 scout-report.md</span>
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 2
-<span class="command-prompt">$</span> mancode workflow requirements &lt;taskId&gt; finalize --file requirements-input.json
+          <h3>一条合法的 V3 顺序</h3>
+          <p>V3 使用显式 TaskRef 和 expected revision。所有持久化变更都由 CLI 完成；不要手工编辑 metadata，也不要使用 legacy <code>--step</code> 协议。</p>
+          <div class="code-wrap"><pre><code><span class="command-prompt"># 创建 actor 和显式 session</span>
+<span class="command-prompt">$</span> mancode team identity create --name "Your name"
+<span class="command-prompt">$</span> mancode context session new --client codex --json
 
-<span class="command-prompt"># Step 3–4：写入 plan.md，到达用户决策闸门</span>
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 3
-<span class="command-prompt"># Agent 写入 plan.md</span>
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 4
-<span class="command-prompt">$</span> mancode workflow decide &lt;taskId&gt; --plan-decision governed_execution
+<span class="command-prompt"># 创建、发现并检查任务</span>
+<span class="command-prompt">$</span> mancode workflow create man "refactor auth module" --session &lt;session-id&gt; --json
+<span class="command-prompt">$</span> mancode workflow list --json
+<span class="command-prompt">$</span> mancode workflow show &lt;local:ULID&gt; --json
 
-<span class="command-prompt"># Step 5–6：实现、初始化验证、记录每个必需 AC</span>
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 5
-<span class="command-prompt"># Agent 实现已确认计划</span>
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 6
-<span class="command-prompt">$</span> mancode workflow verify &lt;taskId&gt; init
-<span class="command-prompt">$</span> mancode workflow verify &lt;taskId&gt; record --acceptance AC-LOGIN --method automated --result passed --evidence "auth tests passed" --command "npm test -- auth" --exit-code 0
+<span class="command-prompt"># 需求和计划闸门（每次使用上一个命令返回的 revision）</span>
+<span class="command-prompt">$</span> mancode workflow requirements &lt;local:ULID&gt; finalize --file requirements-input.json --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
+<span class="command-prompt">$</span> mancode workflow plan &lt;local:ULID&gt; revise --file plan.md --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
+<span class="command-prompt">$</span> mancode workflow plan &lt;local:ULID&gt; confirm --plan-decision governed_execution --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
 
-<span class="command-prompt"># Step 7–9：targeted review、报告、总结、完成</span>
-<span class="command-prompt"># Agent 写入 review-scope.md</span>
-<span class="command-prompt">$</span> mancode workflow review &lt;taskId&gt; init --review-depth targeted --review-domain quality
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 7
-<span class="command-prompt"># Agent 写入 film-report-1.md</span>
-<span class="command-prompt">$</span> mancode workflow review &lt;taskId&gt; complete --review-domain quality --report film-report-1.md
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 9
-<span class="command-prompt"># Agent 写入 summary.md</span>
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --status completed</code></pre><button type="button" data-copy-code>复制</button></div>
+<span class="command-prompt"># 记录规范化评审和验证台账</span>
+<span class="command-prompt">$</span> mancode workflow review &lt;local:ULID&gt; apply --file review-ledger.json --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
+<span class="command-prompt">$</span> mancode workflow verify &lt;local:ULID&gt; apply --file verification-ledger.json --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
+<span class="command-prompt">$</span> mancode workflow complete &lt;local:ULID&gt; --expected-revision &lt;revision&gt; --session &lt;session-id&gt;</code></pre><button type="button" data-copy-code>复制</button></div>
 
           <h3>自动验证、手工确认与修复后重验</h3>
           <table class="docs-table"><thead><tr><th>场景</th><th>必须记录</th><th>闸门行为</th></tr></thead><tbody>
-            <tr><td>自动验证</td><td><code>record</code> 必须包含验收 ID、方法、结果、证据、准确命令和退出码。passed 要求退出码 0，failed 要求非 0。</td><td>所有必需验收标准通过前，Step 7 和 review 都会被阻止。</td></tr>
-            <tr><td>手工验证</td><td><code>require-manual</code> 解释自动化为何不能判断。只有用户亲自执行并确认后，Agent 才能用 <code>confirm-manual</code> 写入观察证据。</td><td>等待确认期间工作流处于 blocked。</td></tr>
-            <tr><td>评审发现</td><td><code>review complete ... --blockers Q1,Q2</code> 保存稳定 ID；用 <code>review remediate --resolved Q1,Q2</code> 进行唯一一轮修复。</td><td>任何 remediation 都会使旧验证失效，Step 9 必须重新运行并记录全部必需验收。</td></tr>
-            <tr><td>用户跳过评审</td><td>在 Step 6 完成验证后，使用 <code>review skip --reason "explicit user request"</code>。</td><td>理由会持久保存，但仍需写 <code>summary.md</code> 并到 Step 9 才能完成。</td></tr>
+            <tr><td>自动验证</td><td>规范化 verification ledger 记录验收项、命令、退出码、证据摘要与结果。</td><td><code>workflow verify ... apply</code> 会拒绝不符合 V3 schema 或 revision 的台账。</td></tr>
+            <tr><td>手工验证</td><td>台账记录自动化不能判断的原因；只有用户明确确认后才能改为 passed。</td><td>必需人工证据未完成时，completion 持续阻塞。</td></tr>
+            <tr><td>评审发现</td><td>规范化 review ledger 保存稳定 blocker ID 及其 remediation 状态。</td><td>应用 review ledger 会使旧验证失效；评审后、完成前必须 apply 当前验证。</td></tr>
+            <tr><td>用户跳过评审</td><td>review ledger 记录用户显式决定和残余风险。</td><td>仍然需要有效 summary 和其余全部门禁。</td></tr>
           </tbody></table>
-          <div class="code-wrap"><pre><code><span class="command-prompt"># 手工验收：require-manual 后必须暂停等待</span>
-<span class="command-prompt">$</span> mancode workflow verify &lt;taskId&gt; require-manual --acceptance AC-UI --evidence "需要前台浏览器和人工判断"
-<span class="command-prompt"># 只有用户明确确认后才能执行</span>
-<span class="command-prompt">$</span> mancode workflow verify &lt;taskId&gt; confirm-manual --acceptance AC-UI --evidence "用户确认交互符合预期"
-
-<span class="command-prompt"># 唯一一轮 blocker remediation</span>
-<span class="command-prompt">$</span> mancode workflow review &lt;taskId&gt; complete --review-domain quality --report film-report-1.md --blockers Q1
-<span class="command-prompt">$</span> mancode workflow update &lt;taskId&gt; --step 9
-<span class="command-prompt">$</span> mancode workflow review &lt;taskId&gt; remediate --resolved Q1
-<span class="command-prompt">$</span> mancode workflow verify &lt;taskId&gt; record --acceptance AC-LOGIN --method automated --result passed --evidence "修复后测试通过" --command "npm test -- auth" --exit-code 0</code></pre><button type="button" data-copy-code>复制</button></div>
+          <div class="code-wrap"><pre><code><span class="command-prompt"># remediation 后更新规范化台账</span>
+<span class="command-prompt">$</span> mancode workflow review &lt;local:ULID&gt; apply --file review-ledger.json --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
+<span class="command-prompt">$</span> mancode workflow verify &lt;local:ULID&gt; apply --file verification-ledger.json --expected-revision &lt;revision&gt; --session &lt;session-id&gt;
+<span class="command-prompt">$</span> mancode workflow complete &lt;local:ULID&gt; --expected-revision &lt;revision&gt; --session &lt;session-id&gt;</code></pre><button type="button" data-copy-code>复制</button></div>
 
           <h3>workflow 子命令速查</h3>
           <table class="docs-table"><thead><tr><th>命令</th><th>用途</th><th>关键选项</th></tr></thead><tbody>
-            <tr><td><code>create</code></td><td>创建 <code>man</code>、<code>manba</code> 或 <code>manteam</code> 记录。</td><td><code>--parent-task</code> 关联诊断子任务；<code>--json</code> 输出 task ID。</td></tr>
-            <tr><td><code>requirements</code></td><td>从 JSON 完成 Step 2 需求台账。</td><td><code>finalize --file</code>。</td></tr>
-            <tr><td><code>update</code></td><td>推进步骤、状态、计划版本或结果。</td><td><code>--step</code>、<code>--status</code>、<code>--plan-version</code>、<code>--blocking-reason</code>、<code>--outcome</code>。通用 <code>--skipped</code> 只允许记录 clarification。</td></tr>
-            <tr><td><code>decide</code></td><td>解决 Step 4 计划闸门。</td><td><code>--plan-decision governed_execution|plan_only</code>。</td></tr>
-            <tr><td><code>handoff</code></td><td>把已确认计划交给 solo，随后关闭该计划。</td><td><code>--to solo</code>，完成后使用 <code>--complete</code>。</td></tr>
-            <tr><td><code>verify</code></td><td>初始化并记录验收证据。</td><td><code>init</code>、<code>record</code>、<code>require-manual</code>、<code>confirm-manual</code>；证据选项包括 <code>--command</code>、<code>--exit-code</code> 和 <code>--evidence-file</code>。</td></tr>
-            <tr><td><code>review</code></td><td>初始化 targeted/full review、保存报告和 blocker、修复一次，或记录用户显式跳过。</td><td><code>--review-depth</code>、<code>--review-domain</code>、<code>--report</code>、<code>--blockers</code>、<code>--resolved</code>、<code>--reason</code>。</td></tr>
-            <tr><td><code>list / show / clean</code></td><td>检查记录或删除较早的已完成记录。</td><td><code>show --json</code>；<code>clean --older-than 30d --dry-run</code>。</td></tr>
+            <tr><td><code>create</code></td><td>创建 <code>man</code>、<code>manba</code> 或 <code>manteam</code> 记录。</td><td><code>--parent &lt;TaskRef&gt;</code> 关联诊断子任务；<code>--json</code> 输出 TaskRef。</td></tr>
+            <tr><td><code>requirements</code></td><td>完成结构化需求台账。</td><td><code>finalize --file --expected-revision --session</code>。</td></tr>
+            <tr><td><code>plan</code></td><td>修订计划或确认执行决策。</td><td><code>revise --file</code>；<code>confirm --plan-decision</code>；两者都需要 revision 和 session。</td></tr>
+            <tr><td><code>update</code></td><td>改变生命周期状态或阻塞原因。</td><td><code>--status --expected-revision --session</code>；治理字段使用专用命令。</td></tr>
+            <tr><td><code>handoff</code></td><td>把已确认的本地计划交给 solo，随后关闭。</td><td><code>--to solo</code> 或 <code>--complete</code>，并传 revision 与 session。</td></tr>
+            <tr><td><code>verify / review</code></td><td>应用规范化 V3 台账。</td><td><code>apply --file --expected-revision --session</code>。</td></tr>
+            <tr><td><code>list / show / clean</code></td><td>列出或检查 V3 TaskRef；<code>clean</code> 不是删除 V3 权威数据的命令。</td><td><code>show &lt;namespace:ULID&gt; --json</code>；保留清理使用 <code>context compact --dry-run</code>。</td></tr>
           </tbody></table>
         </section>
 
@@ -324,16 +307,14 @@ $manteam</code></pre><button type="button" data-copy-code>复制</button></div><
 
         <section class="doc-section" id="uninstall" data-searchable>
           <h2>安全卸载</h2>
-          <p>卸载会保留用户自己编写的 rules、instructions 和无关的 Claude settings。删除前先检查工作流记录，避免丢失仍然需要的决策或证据。</p>
+          <p>卸载单个平台会保留用户自己编写的 rules、instructions、无关的 Claude settings 和 V3 工作流权威数据。使用 <code>context compact --dry-run</code> 检查可清理的运行时保留记录。</p>
           <h3>移除一个适配器</h3>
           <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode uninstall cursor --force</code></pre><button type="button" data-copy-code>复制</button></div>
-          <h3>完整重装</h3>
-          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode uninstall --all --force
-<span class="command-prompt">$</span> mancode init
-<span class="command-prompt">$</span> mancode install &lt;platform&gt;</code></pre><button type="button" data-copy-code>复制</button></div>
-          <h3>完全移除 mancode</h3>
-          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode uninstall --all --force
-<span class="command-prompt">$</span> npm uninstall -g mancode</code></pre><button type="button" data-copy-code>复制</button></div>
+          <h3>重装一个适配器</h3>
+          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode uninstall claude-code --force
+<span class="command-prompt">$</span> mancode install claude-code</code></pre><button type="button" data-copy-code>复制</button></div>
+          <h3>移除 CLI</h3>
+          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> npm uninstall -g mancode</code></pre><button type="button" data-copy-code>复制</button></div>
         </section>
 
         <section class="doc-section" id="troubleshooting" data-searchable>
@@ -347,7 +328,7 @@ $manteam</code></pre><button type="button" data-copy-code>复制</button></div><
           <h3>Cursor rules 没有触发</h3>
           <p>确认 <code>.cursor/rules/mancode-*.mdc</code> 和 <code>.cursor/commands/*.md</code> 都存在。核心上下文与 solo rules 持续生效；高强度规则按描述触发，因此应显式调用生成的模式命令。</p>
           <h3>workflow 命令被拒绝</h3>
-          <p>把拒绝当作流程闸门，而不是元数据损坏。使用 <code>mancode workflow show &lt;taskId&gt; --json</code> 检查步骤、需求就绪状态、计划决策、验证、评审域和 blocker。不要直接编辑 <code>metadata.json</code>。</p>
+          <p>把拒绝当作流程闸门，而不是元数据损坏。先用 <code>mancode workflow list --json</code> 找到 TaskRef，再用 <code>mancode workflow show &lt;namespace:ULID&gt; --json</code> 检查元数据、revision、aggregate 和 blocker。不要手工编辑 V3 metadata。</p>
           <h3>项目事实已经过期</h3>
           <p>添加 Git、manifest、依赖或验证脚本后执行 <code>mancode refresh-project</code>；UI token 改变时执行 <code>refresh-style</code>。只有静态适配器的生成文件需要更新时，才重新安装对应平台。</p>
         </section>

--- a/website/index.html
+++ b/website/index.html
@@ -253,7 +253,7 @@
           <div><p class="eyebrow">/man workflow</p><h2>From scout report<br />to final buzzer.</h2></div>
           <p>
             Every planning run leaves a readable trail under
-            <code>.mancode/workflows/&lt;taskId&gt;/</code>. After approval, hand the plan to lightweight solo
+            <code>.mancode/&lt;namespace&gt;/workflows/&lt;ULID&gt;/</code>. After approval, hand the plan to lightweight solo
             delivery or continue through the full governed workflow.
           </p>
         </div>
@@ -299,10 +299,10 @@
             <header><span></span><span></span><span></span><b>project / local</b></header>
             <pre><code><i>your-project/</i>
 ├── <strong>.mancode/</strong>
-│   ├── project-profile.json
-│   ├── aesthetics/style-tokens.json
-│   ├── workflows/&lt;taskId&gt;/
-│   └── memory/
+│   ├── shared/context/project.json
+│   ├── local/cache/style-tokens.json
+│   ├── local/workflows/&lt;ULID&gt;/
+│   └── shared/team/
 ├── .claude/
 ├── .cursor/rules/
 ├── .agents/skills/
@@ -439,7 +439,7 @@
         <a href="https://github.com/whitelonng/mancode/blob/main/README.md">中文</a>
         <a href="https://github.com/whitelonng/mancode/blob/main/LICENSE">AGPL-3.0</a>
       </div>
-      <span class="footer-status"><i></i> Stable / v0.3.13</span>
+      <span class="footer-status"><i></i> V3 Beta / v0.3.13</span>
     </footer>
   </body>
 </html>

--- a/website/index.zh-CN.html
+++ b/website/index.zh-CN.html
@@ -38,7 +38,7 @@
 
       <section class="modes-section section-dark" id="modes"><div class="section-kicker reveal"><span>02 / 五档强度</span><span>按风险匹配流程。</span></div><div class="section-title-row reveal"><h2>不是每个任务<br />都是抢七。</h2><p>同一个编码 Agent，日常任务轻装上阵；需要正式方案时先用 /man 对齐需求和计划，再选择 solo 轻量开发或完整治理。针对最新模型自带审查的特点，mancode 会限制 review 轮次，同时给不主动审查的模型保留质量门槛。</p></div><div class="mode-guide-home reveal"><article><small>日常训练</small><h3>solo</h3><p>一次受限 diff 自检、最窄验证，不调用额外 reviewer。</p></article><article><small>真实诊断</small><h3>/manba</h3><p>复现、定位根因、驱动真实路径并回归验证。</p></article><article class="featured-mode"><small>先计划再选择</small><h3>/man</h3><p>引导需求对齐、方案推荐和持久计划；确认后选择 solo 或完整九步治理。</p></article><article><small>团队协作</small><h3>/manteam</h3><p>共享项目记忆、决策记录与协作约定。</p></article><article><small>季前赛</small><h3>/manps</h3><p>检测陈旧 TODO、依赖风险和硬编码设计值。</p></article></div></section>
 
-      <section class="workflow-section" id="workflow"><div class="section-kicker reveal"><span>03 / 先计划再选择</span><span>solo 交付或完整治理。</span></div><div class="workflow-lead reveal"><div><p class="eyebrow">/man 工作流</p><h2>从需求对齐<br />到确认计划。</h2></div><p>每次规划都会在 <code>.mancode/workflows/&lt;taskId&gt;/</code> 产生可读记录。计划确认后，可交给 solo 轻量开发，也可继续完整九步治理。</p></div><ol class="workflow-grid reveal"><li class="phase-scout"><b>01</b><span>球探报告</span><small>梳理代码、风险与未知项</small></li><li class="phase-scout"><b>02</b><span>需求澄清</span><small>确认真正要解决的问题</small></li><li class="phase-plan"><b>03</b><span>计划</span><small>输出可验证步骤</small></li><li class="phase-plan"><b>04</b><span>计划关卡</span><small>solo、完整治理、仅计划或修改</small></li><li class="phase-run featured"><b>05</b><span>实施</span><small>完整 /man 才进入</small></li><li class="phase-run"><b>06</b><span>验证与范围</span><small>验证后选择审查深度</small></li><li class="phase-review"><b>07</b><span>定向审查</span><small>有证据的质量 finding</small></li><li class="phase-review"><b>08</b><span>风险防守</span><small>高风险时审查安全边界</small></li><li class="phase-close"><b>09</b><span>收尾</span><small>一轮修复、复验、停止</small></li></ol></section>
+      <section class="workflow-section" id="workflow"><div class="section-kicker reveal"><span>03 / 先计划再选择</span><span>solo 交付或完整治理。</span></div><div class="workflow-lead reveal"><div><p class="eyebrow">/man 工作流</p><h2>从需求对齐<br />到确认计划。</h2></div><p>每次规划都会在 <code>.mancode/&lt;namespace&gt;/workflows/&lt;ULID&gt;/</code> 产生可读记录。计划确认后，可交给 solo 轻量开发，也可继续完整九步治理。</p></div><ol class="workflow-grid reveal"><li class="phase-scout"><b>01</b><span>球探报告</span><small>梳理代码、风险与未知项</small></li><li class="phase-scout"><b>02</b><span>需求澄清</span><small>确认真正要解决的问题</small></li><li class="phase-plan"><b>03</b><span>计划</span><small>输出可验证步骤</small></li><li class="phase-plan"><b>04</b><span>计划关卡</span><small>solo、完整治理、仅计划或修改</small></li><li class="phase-run featured"><b>05</b><span>实施</span><small>完整 /man 才进入</small></li><li class="phase-run"><b>06</b><span>验证与范围</span><small>验证后选择审查深度</small></li><li class="phase-review"><b>07</b><span>定向审查</span><small>有证据的质量 finding</small></li><li class="phase-review"><b>08</b><span>风险防守</span><small>高风险时审查安全边界</small></li><li class="phase-close"><b>09</b><span>收尾</span><small>一轮修复、复验、停止</small></li></ol></section>
 
       <section class="awareness-section section-dark" id="context">
         <div class="section-kicker reveal"><span>04 / 项目感知</span><span>你的代码库本来就有自己的战术。</span></div>
@@ -52,10 +52,10 @@
             <header><span></span><span></span><span></span><b>project / local</b></header>
             <pre><code><i>your-project/</i>
 ├── <strong>.mancode/</strong>
-│   ├── project-profile.json
-│   ├── aesthetics/style-tokens.json
-│   ├── workflows/&lt;taskId&gt;/
-│   └── memory/
+│   ├── shared/context/project.json
+│   ├── local/cache/style-tokens.json
+│   ├── local/workflows/&lt;ULID&gt;/
+│   └── shared/team/
 ├── .claude/
 ├── .cursor/rules/
 ├── .agents/skills/
@@ -88,6 +88,6 @@
 
       <section class="final-cta"><div class="final-cta-mark" aria-hidden="true">M</div><p class="reveal">简单任务少一点仪式。<br />关键任务多一点纪律。</p><h2 class="reveal">别再替 AI<br />收拾臃肿。</h2><div class="final-actions reveal"><div class="command-bar command-light"><code><span>&gt;</span> npm install -g mancode</code><button type="button" data-copy="npm install -g mancode">复制</button></div><a class="button button-dark" href="https://github.com/whitelonng/mancode">GitHub 上查看 ↗</a></div></section>
     </main>
-    <footer class="site-footer"><a class="brand footer-brand" href="#top"><img src="./logo.png" alt="" /><span>mancode</span></a><p>AI 编码 Agent 工作流调度工具。<br />日常训练，关键任务季后赛。</p><div class="footer-links"><a href="https://github.com/whitelonng/mancode">GitHub</a><a href="./docs.zh-CN.html">中文文档</a><a href="./docs.html">English</a><a href="https://github.com/whitelonng/mancode/blob/main/LICENSE">AGPL-3.0</a></div><span class="footer-status"><i></i> Stable / v0.3.13</span></footer>
+    <footer class="site-footer"><a class="brand footer-brand" href="#top"><img src="./logo.png" alt="" /><span>mancode</span></a><p>AI 编码 Agent 工作流调度工具。<br />日常训练，关键任务季后赛。</p><div class="footer-links"><a href="https://github.com/whitelonng/mancode">GitHub</a><a href="./docs.zh-CN.html">中文文档</a><a href="./docs.html">English</a><a href="https://github.com/whitelonng/mancode/blob/main/LICENSE">AGPL-3.0</a></div><span class="footer-status"><i></i> V3 Beta / v0.3.13</span></footer>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- add V3 workflow discovery through `workflow list` and `workflow show`
- protect durable V3 authority from workflow cleanup and bulk uninstall paths
- align status output, README files, and the bilingual website with the V3 TaskRef/revision contract
- add a GitHub Actions quality gate and regression coverage

## Why

The V3 beta release surface still exposed legacy workflow guidance and lacked supported discovery commands. The documentation also showed a review/verification order that would invalidate verification before completion. This change makes the CLI and public guidance consistent before real-host beta acceptance begins.

## Impact

Users can discover and inspect V3 workflows without relying on a session pointer. Cleanup commands now clearly preserve durable workflow authority, and the published documentation uses executable V3 command sequences.

## Validation

- `npm run prepublishOnly`
- 113 test files, 768 tests passed
- `git diff --check`
- `npm pack --dry-run --json --ignore-scripts`
