### PR TITLE
chore: release mancode 0.5.0

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="./LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg?style=flat-square" alt="License: AGPL-3.0" /></a>
   <a href="https://www.npmjs.com/package/mancode"><img src="https://img.shields.io/npm/v/mancode?style=flat-square" alt="npm version" /></a>
-  <img src="https://img.shields.io/badge/status-Continuity%20v0.4.2-2f855a?style=flat-square" alt="Status: mancode Continuity v0.4.2" />
+  <img src="https://img.shields.io/badge/status-Continuity%20v0.5.0-2f855a?style=flat-square" alt="Status: mancode Continuity v0.5.0" />
   <img src="https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Cursor%20%7C%20Codex%20%7C%20Copilot%20%7C%20ZCode-5865F2?style=flat-square" alt="Platforms: Claude Code, Cursor, Codex in ChatGPT desktop and CLI, GitHub Copilot, ZCode" />
 </p>
 
@@ -382,7 +382,7 @@ it should behave, and why previous decisions were made.
 
 ## Installation
 
-**Status**: mancode Continuity v0.4.2. Claude Code, Cursor, Codex in the ChatGPT
+**Status**: mancode Continuity v0.5.0. Claude Code, Cursor, Codex in the ChatGPT
 desktop app and CLI, GitHub Copilot, and ZCode adapters are included.
 
 Requires Node.js 20 or newer. macOS, Linux, Windows CMD, PowerShell, and Git Bash
@@ -493,7 +493,7 @@ mancode version
 Simplified output:
 
 ```text
-mancode v0.4.2
+mancode v0.5.0
 
 Project:     my-app
 Runtime:     ready

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="./LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg?style=flat-square" alt="许可证：AGPL-3.0" /></a>
   <a href="https://www.npmjs.com/package/mancode"><img src="https://img.shields.io/npm/v/mancode?style=flat-square" alt="npm 版本" /></a>
-  <img src="https://img.shields.io/badge/status-Continuity%20v0.4.2-2f855a?style=flat-square" alt="状态：mancode Continuity v0.4.2" />
+  <img src="https://img.shields.io/badge/status-Continuity%20v0.5.0-2f855a?style=flat-square" alt="状态：mancode Continuity v0.5.0" />
   <img src="https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Cursor%20%7C%20Codex%20%7C%20Copilot%20%7C%20ZCode-5865F2?style=flat-square" alt="平台：Claude Code、Cursor、ChatGPT 桌面端 Codex、Codex CLI、GitHub Copilot、ZCode" />
 </p>
 
@@ -336,7 +336,7 @@ src/components/
 
 ## 安装
 
-**状态**：mancode Continuity v0.4.2。Claude Code、Cursor、ChatGPT 桌面端中的
+**状态**：mancode Continuity v0.5.0。Claude Code、Cursor、ChatGPT 桌面端中的
 Codex、Codex CLI、GitHub Copilot 和 ZCode adapter 均已接入。
 
 需要 Node.js 20 或更高版本。原生支持 macOS、Linux、Windows CMD、
@@ -445,7 +445,7 @@ mancode version
 以下是简化输出示例：
 
 ```text
-mancode v0.4.2
+mancode v0.5.0
 
 Project:     my-app
 Runtime:     ready

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mancode",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mancode",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "commander": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mancode",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "AI coding agent workflow harness with mancode Continuity for cross-conversation tasks, decisions, verification, and team coordination.",
   "type": "module",
   "license": "AGPL-3.0-only",

--- a/website/docs.html
+++ b/website/docs.html
@@ -24,7 +24,7 @@
 
     <header class="docs-topbar">
       <a class="brand" href="./index.html" aria-label="mancode home"><img src="./logo.png" alt="" /><span>mancode</span><i aria-hidden="true"></i></a>
-      <span class="docs-wordmark">Documentation / v0.4.2</span>
+      <span class="docs-wordmark">Documentation / v0.5.0</span>
       <div class="docs-top-links">
         <a href="./index.html">Website</a>
         <a href="https://github.com/whitelonng/mancode">GitHub</a>

--- a/website/docs.zh-CN.html
+++ b/website/docs.zh-CN.html
@@ -24,7 +24,7 @@
 
     <header class="docs-topbar">
       <a class="brand" href="./index.zh-CN.html" aria-label="mancode 首页"><img src="./logo.png" alt="" /><span>mancode</span><i aria-hidden="true"></i></a>
-      <span class="docs-wordmark">文档 / v0.4.2</span>
+      <span class="docs-wordmark">文档 / v0.5.0</span>
       <div class="docs-top-links">
         <a href="./index.zh-CN.html">官网</a>
         <a href="https://github.com/whitelonng/mancode">GitHub</a>

--- a/website/index.html
+++ b/website/index.html
@@ -439,7 +439,7 @@
         <a href="https://github.com/whitelonng/mancode/blob/main/README.md">中文</a>
         <a href="https://github.com/whitelonng/mancode/blob/main/LICENSE">AGPL-3.0</a>
       </div>
-      <span class="footer-status"><i></i> Continuity / v0.4.2</span>
+      <span class="footer-status"><i></i> Continuity / v0.5.0</span>
     </footer>
   </body>
 </html>

--- a/website/index.zh-CN.html
+++ b/website/index.zh-CN.html
@@ -88,6 +88,6 @@
 
       <section class="final-cta"><div class="final-cta-mark" aria-hidden="true">M</div><p class="reveal">简单任务少一点仪式。<br />关键任务多一点纪律。</p><h2 class="reveal">别再替 AI<br />收拾臃肿。</h2><div class="final-actions reveal"><div class="command-bar command-light"><code><span>&gt;</span> npm install -g mancode</code><button type="button" data-copy="npm install -g mancode">复制</button></div><a class="button button-dark" href="https://github.com/whitelonng/mancode">GitHub 上查看 ↗</a></div></section>
     </main>
-    <footer class="site-footer"><a class="brand footer-brand" href="#top"><img src="./logo.png" alt="" /><span>mancode</span></a><p>AI 编码 Agent 工作流调度工具。<br />日常训练，关键任务季后赛。</p><div class="footer-links"><a href="https://github.com/whitelonng/mancode">GitHub</a><a href="./docs.zh-CN.html">中文文档</a><a href="./docs.html">English</a><a href="https://github.com/whitelonng/mancode/blob/main/LICENSE">AGPL-3.0</a></div><span class="footer-status"><i></i> Continuity / v0.4.2</span></footer>
+    <footer class="site-footer"><a class="brand footer-brand" href="#top"><img src="./logo.png" alt="" /><span>mancode</span></a><p>AI 编码 Agent 工作流调度工具。<br />日常训练，关键任务季后赛。</p><div class="footer-links"><a href="https://github.com/whitelonng/mancode">GitHub</a><a href="./docs.zh-CN.html">中文文档</a><a href="./docs.html">English</a><a href="https://github.com/whitelonng/mancode/blob/main/LICENSE">AGPL-3.0</a></div><span class="footer-status"><i></i> Continuity / v0.5.0</span></footer>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- bump the package and lockfile version to 0.5.0
- update README and website version labels
- prepare the latest design workflow changes already contained in main for npm publication

## Verification

- npm run lint
- npm run typecheck
- npm run build
- npm run test:dist
- npm run test:windows-smoke
- npm test -- --silent (122 files, 857 tests passed)
- git diff --check