### PR TITLE
docs: update website for 0.5.0 design policy

### DIFF
--- a/tests/website-docs.test.ts
+++ b/tests/website-docs.test.ts
@@ -54,6 +54,10 @@ describe('website documentation', () => {
         'refresh-project',
         'manps [area]',
         '--remediate',
+        'design configure --expected-revision',
+        '--confirm-experimental',
+        'forbid-as-interface-icon',
+        '--browser-validation',
         'workflow verify',
         'workflow review',
         'governed_execution',
@@ -139,17 +143,23 @@ describe('website documentation', () => {
     expect(english).toContain('Project rules · commands');
     expect(english).toContain('Repository instructions · prompts');
     expect(english).toContain('Preview adapter');
+    expect(english).toContain('id="design"');
+    expect(english).toContain('05 / Design policy');
+    expect(english).toContain('Present<br />2–3 routes.');
     expect(english).toContain('id="continuity"');
-    expect(english).toContain('06 / Cross-session continuity');
+    expect(english).toContain('07 / Cross-session continuity');
     expect(english).toContain('Raw chat history is not copied');
-    expect(english).toContain('07 / Quick start');
+    expect(english).toContain('08 / Quick start');
     expect(chinese).toContain('id="context"');
     expect(chinese).toContain('04 / 项目感知');
-    expect(chinese).toContain('05 / 适配器');
+    expect(chinese).toContain('id="design"');
+    expect(chinese).toContain('05 / 设计策略');
+    expect(chinese).toContain('先给出<br />2–3 个方向。');
+    expect(chinese).toContain('06 / 适配器');
     expect(chinese).toContain('id="continuity"');
-    expect(chinese).toContain('06 / 跨会话续接');
+    expect(chinese).toContain('07 / 跨会话续接');
     expect(chinese).toContain('不复制原始聊天记录');
-    expect(chinese).toContain('07 / 快速开始');
+    expect(chinese).toContain('08 / 快速开始');
     expect(chinese).toContain('交付干净');
     expect(chinese).toContain('代码，避免');
     expect(chinese).toContain('AI 屎山。');
@@ -157,6 +167,23 @@ describe('website documentation', () => {
     const version = await readPackageVersion();
     expect(english).toContain(`Continuity / v${version}`);
     expect(chinese).toContain(`Continuity / v${version}`);
+  });
+
+  it('documents the opt-in design policy and its safety boundaries', async () => {
+    for (const name of ['docs.html', 'docs.zh-CN.html']) {
+      const html = await readPage(name);
+      expect(html).toContain('id="design"');
+      expect(html).toContain('<h3>preserve</h3>');
+      expect(html).toContain('<h3>refine</h3>');
+      expect(html).toContain('<h3>experimental</h3>');
+      expect(html).toContain('mancode design status --json');
+      expect(html).toContain('mancode design context --json');
+      expect(html).toContain('--icons lucide');
+      expect(html).toContain('.mancode/shared/context/design-policy.json');
+    }
+
+    expect(await readPage('docs.html')).toContain('does not install a package');
+    expect(await readPage('docs.zh-CN.html')).toContain('不会自动安装依赖');
   });
 
   it('documents the cross-session boundary in both languages', async () => {

--- a/website/docs.css
+++ b/website/docs.css
@@ -593,6 +593,18 @@
   line-height: 1.65;
 }
 
+.design-presets {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.design-presets article:nth-child(2) {
+  position: relative;
+  background:
+    linear-gradient(rgba(255, 100, 20, 0.07), rgba(255, 100, 20, 0.02)),
+    var(--docs-panel);
+  box-shadow: inset 0 3px 0 var(--orange);
+}
+
 .docs-admonition {
   margin-top: 24px;
   padding: 18px 20px;

--- a/website/docs.html
+++ b/website/docs.html
@@ -28,7 +28,7 @@
       <div class="docs-top-links">
         <a href="./index.html">Website</a>
         <a href="https://github.com/whitelonng/mancode">GitHub</a>
-        <button class="docs-theme-toggle" type="button" data-theme-toggle aria-label="Switch to light theme" title="Switch theme"><span aria-hidden="true">◐</span></button>
+        <button class="docs-theme-toggle" type="button" data-theme-toggle aria-label="Switch to light theme" title="Switch theme"><span class="theme-toggle-icon" aria-hidden="true"><svg class="theme-icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.93 4.93l1.42 1.42M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"></path></svg><svg class="theme-icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 1 0 9 9 9 9 0 0 1-9-9Z"></path></svg></span></button>
         <a class="language-link" href="./docs.zh-CN.html" lang="zh-CN" aria-label="切换到中文">中</a>
       </div>
     </header>
@@ -44,7 +44,7 @@
         <p class="docs-nav-hint" aria-hidden="true">Swipe to see every topic →</p>
         <nav class="docs-nav">
           <div class="docs-nav-group"><p>Start here</p><a class="active" href="#overview">Overview</a><a href="#install">Install &amp; initialize</a><a href="#files">Files &amp; privacy</a><a href="#continuity">Cross-session continuity</a><a href="#recommend">Choose a mode</a></div>
-          <div class="docs-nav-group"><p>Use mancode</p><a href="#modes">Invoke modes</a><a href="#commands">CLI reference</a><a href="#workflow">Study /man</a><a href="#platforms">Platforms</a></div>
+          <div class="docs-nav-group"><p>Use mancode</p><a href="#design">Design policy</a><a href="#modes">Invoke modes</a><a href="#commands">CLI reference</a><a href="#workflow">Study /man</a><a href="#platforms">Platforms</a></div>
           <div class="docs-nav-group"><p>Maintain</p><a href="#style">Refresh context</a><a href="#uninstall">Uninstall</a><a href="#troubleshooting">Troubleshooting</a></div>
           <div class="docs-nav-group"><p>Links</p><a href="./index.html">Marketing site</a><a href="./docs.zh-CN.html">中文文档</a><a href="https://github.com/whitelonng/mancode/blob/main/README.en.md">README on GitHub</a></div>
         </nav>
@@ -83,7 +83,7 @@
             <tr><td><code>--platform LIST</code></td><td>You know the target agents</td><td>Installs one or more of <code>claude-code</code>, <code>cursor</code>, <code>codex</code>, <code>copilot</code>, and <code>zcode</code>.</td></tr>
             <tr><td><code>--empty</code></td><td>The directory is intentionally empty</td><td>Allows generic-project initialization without <code>git init</code> or a package manifest.</td></tr>
             <tr><td><code>--team</code> / <code>--no-team</code></td><td>Auto-detection is not the policy you want</td><td>Forces shared-memory mode on or off.</td></tr>
-            <tr><td><code>--style NAME</code></td><td>You have a named visual preference</td><td>Saves it as the default style preference.</td></tr>
+            <tr><td><code>--style NAME</code></td><td>You explicitly initialize with <code>--legacy</code></td><td>Stores the old free-text style preference. Continuity projects use the revisioned <code>mancode design</code> policy instead.</td></tr>
             <tr><td><code>--lang en|zh-CN</code></td><td>You need deterministic generated text</td><td>Sets the generated-content locale.</td></tr>
           </tbody></table>
 
@@ -131,6 +131,35 @@
           <div class="docs-admonition"><strong>Rule of thumb</strong><p>Use <code>/man</code> when a wrong choice would be expensive, hard to reverse, or difficult to inspect later—not simply because the task is large.</p></div>
         </section>
 
+        <section class="doc-section" id="design" data-searchable>
+          <h2>Set a design policy</h2>
+          <p>The design policy is an explicit, opt-in Continuity feature for UI work. <code>mancode init</code> does not create it. When no valid policy is active, design context fails open to <code>preserve</code>, so ordinary coding and workflow recovery are not blocked.</p>
+          <div class="mode-guide design-presets">
+            <article><small>Lowest disruption</small><h3>preserve</h3><p>Keeps the existing hierarchy, layout, component system, and interaction patterns. The agent makes only the UI changes required by the task.</p></article>
+            <article><small>Recommended default</small><h3>refine</h3><p>Improves hierarchy, typography, spacing, states, and responsive behavior without changing the product structure.</p></article>
+            <article><small>Explicit confirmation</small><h3>experimental</h3><p>Allows one stronger product-appropriate composition and purposeful motion after <code>--confirm-experimental</code>. It still cannot expand scope or invent product features.</p></article>
+          </div>
+
+          <h3>Choose a direction before implementation</h3>
+          <p>For a new UI surface or aesthetic redesign, if the user has not chosen a visual direction, the agent presents 2–3 distinct, product-appropriate directions with concise tradeoffs and a recommendation, then waits for a choice. Scoped UI fixes, work inside an established design system, and tasks with an already selected direction continue directly.</p>
+          <div class="docs-note"><strong>Context decides the intensity</strong><p>Brand, campaign, editorial, portfolio, and launch surfaces may use a memorable first viewport and one visual motif across the page. Task-oriented products keep workflow clarity ahead of spectacle.</p></div>
+
+          <h3>Configure and inspect</h3>
+          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode design status --json
+<span class="command-prompt">$</span> mancode design configure --expected-revision 0 --preset refine --icons lucide --emoji forbid-as-interface-icon --motion purposeful --browser-validation when-available
+<span class="command-prompt">$</span> mancode design context --json
+<span class="command-prompt">$</span> mancode design configure --expected-revision 1 --preset experimental --confirm-experimental
+<span class="command-prompt">$</span> mancode design disable --expected-revision 2</code></pre><button type="button" data-copy-code>Copy</button></div>
+          <table class="docs-table"><thead><tr><th>Control</th><th>Accepted values</th><th>Boundary</th></tr></thead><tbody>
+            <tr><td><code>--preset</code></td><td><code>preserve</code>, <code>refine</code>, <code>experimental</code></td><td><code>experimental</code> requires explicit confirmation every time it is enabled.</td></tr>
+            <tr><td><code>--icons</code></td><td><code>existing-first</code>, <code>lucide</code></td><td>Choosing Lucide does not install a package; dependency changes still require task approval.</td></tr>
+            <tr><td><code>--emoji</code></td><td><code>allow</code>, <code>forbid-as-interface-icon</code></td><td>The stricter value prevents emoji from replacing interface icons.</td></tr>
+            <tr><td><code>--motion</code></td><td><code>minimal</code>, <code>purposeful</code></td><td>Motion must support hierarchy, feedback, or narrative—not obscure the core workflow.</td></tr>
+            <tr><td><code>--browser-validation</code></td><td><code>off</code>, <code>when-available</code>, <code>required</code></td><td><code>required</code> creates a hard quality gate when browser verification cannot run.</td></tr>
+          </tbody></table>
+          <div class="docs-admonition"><strong>Scope stays fixed</strong><p>No design preset authorizes new features, information-architecture changes, silent dependency installation, or unrelated redesign. The policy is stored at <code>.mancode/shared/context/design-policy.json</code> and should be reviewed like any other repository configuration.</p></div>
+        </section>
+
         <section class="doc-section" id="modes" data-searchable>
           <h2>Invoke a mode</h2>
           <p>Mode names are portable, but invocation follows the extension model of each agent. Run them in the agent chat—not in your operating-system shell. <code>/mansolo</code> or <code>$mansolo</code> explicitly returns to the default <code>solo</code> mode.</p>
@@ -168,7 +197,7 @@ $manteam</code></pre><button type="button" data-copy-code>Copy</button></div></a
           <h2>CLI reference</h2>
           <p>The CLI installs adapters and enforces durable workflow state. Run state-reading commands from an initialized project. Invalid transitions fail safely instead of silently editing workflow metadata.</p>
           <div class="command-list">
-            <article class="command-card"><header><h3>mancode init</h3><span>Start</span></header><p>Creates <code>.mancode/</code>, detects the project, scans style tokens where relevant, and installs adapters.</p><ul><li>Options: <code>--force</code>, <code>--yes</code>, <code>--team</code>, <code>--no-team</code>, <code>--style &lt;name&gt;</code>, <code>--platform &lt;list&gt;</code>, <code>--empty</code>, <code>--lang &lt;locale&gt;</code>.</li></ul></article>
+            <article class="command-card"><header><h3>mancode init</h3><span>Start</span></header><p>Creates <code>.mancode/</code>, detects the project, scans style tokens where relevant, and installs adapters.</p><ul><li>Options: <code>--force</code>, <code>--yes</code>, <code>--team</code>, <code>--no-team</code>, <code>--platform &lt;list&gt;</code>, <code>--empty</code>, <code>--lang &lt;locale&gt;</code>. <code>--style &lt;name&gt;</code> is legacy-only.</li></ul></article>
             <article class="command-card"><header><h3>mancode install [platform]</h3><span>Adapter</span></header><p>Installs one adapter through the journaled upgrade path after initialization.</p><ul><li><code>--confirm --operation-id &lt;operationId&gt;</code> and an active session authorize the previewed managed writes.</li><li><code>--minimal</code> remains available for legacy compatibility.</li></ul></article>
             <article class="command-card"><header><h3>mancode adapter status | upgrade</h3><span>Repair</span></header><p>Compares managed-content digests, stages changes with <code>--dry-run</code>, and publishes that exact preview only with <code>--confirm --operation-id &lt;operationId&gt;</code>.</p></article>
             <article class="command-card"><header><h3>mancode project upgrade --policy 2</h3><span>Policy</span></header><p>Previews or commits the project Policy 2 default without rewriting existing workflows. A commit requires the preview's operation ID and an active session.</p></article>
@@ -176,6 +205,7 @@ $manteam</code></pre><button type="button" data-copy-code>Copy</button></div></a
             <article class="command-card"><header><h3>mancode list-platforms</h3><span>Discover</span></header><p>Lists adapters known to the installed CLI and marks those already configured in the project.</p></article>
             <article class="command-card"><header><h3>mancode workflow &lt;subcommand&gt;</h3><span>Govern</span></header><p>Creates and validates Continuity requirements, plans, verification evidence, reviews, remediation, and completion.</p><ul><li>Inspect with <code>list</code> and <code>show &lt;namespace:ULID&gt; [--json]</code>.</li><li>Use <code>context compact --dry-run</code> to inspect removable runtime records; Continuity workflow authority is not deleted by <code>workflow clean</code>.</li></ul></article>
             <article class="command-card"><header><h3>mancode manps [area]</h3><span>Scan</span></header><p>Runs a deterministic health scan for <code>all</code>, <code>deps</code>, <code>security</code>, <code>dead-code</code>, <code>config</code>.</p><ul><li><code>--json</code> emits machine-readable output.</li><li><code>--remediate</code> enters the explicit remediation path; the default is scan-only.</li></ul></article>
+            <article class="command-card"><header><h3>mancode design status | context | configure | disable</h3><span>Design</span></header><p>Inspects effective UI guidance or changes the revisioned project design policy. Configuration requires <code>--expected-revision &lt;n&gt;</code>; experimental mode also requires <code>--confirm-experimental</code>.</p></article>
             <article class="command-card"><header><h3>mancode refresh-project</h3><span>Rescan</span></header><p>Refreshes project facts after adding Git, a manifest, a framework, or validation commands, then reports stale adapters.</p></article>
             <article class="command-card"><header><h3>mancode refresh-style</h3><span>Design</span></header><p>Refreshes the project profile and design tokens. Preview any adapter repair with <code>mancode adapter upgrade --platform &lt;platform&gt; --dry-run</code>.</p></article>
             <article class="command-card"><header><h3>mancode uninstall [platform]</h3><span>Remove</span></header><p>Removes one Continuity adapter. Continuity protects authority from bulk removal; use <code>context compact --dry-run</code> for retention candidates. The <code>--all</code> form is legacy-only.</p></article>

--- a/website/docs.zh-CN.html
+++ b/website/docs.zh-CN.html
@@ -28,7 +28,7 @@
       <div class="docs-top-links">
         <a href="./index.zh-CN.html">官网</a>
         <a href="https://github.com/whitelonng/mancode">GitHub</a>
-        <button class="docs-theme-toggle" type="button" data-theme-toggle aria-label="切换到白色主题" title="切换主题"><span aria-hidden="true">◐</span></button>
+        <button class="docs-theme-toggle" type="button" data-theme-toggle aria-label="切换到白色主题" title="切换主题"><span class="theme-toggle-icon" aria-hidden="true"><svg class="theme-icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.93 4.93l1.42 1.42M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"></path></svg><svg class="theme-icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 1 0 9 9 9 9 0 0 1-9-9Z"></path></svg></span></button>
         <a class="language-link" href="./docs.html" lang="en" aria-label="Switch to English">EN</a>
       </div>
     </header>
@@ -44,7 +44,7 @@
         <p class="docs-nav-hint" aria-hidden="true">横向滑动查看全部主题 →</p>
         <nav class="docs-nav">
           <div class="docs-nav-group"><p>从这里开始</p><a class="active" href="#overview">概览</a><a href="#install">安装与初始化</a><a href="#files">文件与隐私</a><a href="#continuity">跨会话续接</a><a href="#recommend">选择模式</a></div>
-          <div class="docs-nav-group"><p>使用 mancode</p><a href="#modes">调用模式</a><a href="#commands">CLI 参考</a><a href="#workflow">深入研究 /man</a><a href="#platforms">平台适配</a></div>
+          <div class="docs-nav-group"><p>使用 mancode</p><a href="#design">设计策略</a><a href="#modes">调用模式</a><a href="#commands">CLI 参考</a><a href="#workflow">深入研究 /man</a><a href="#platforms">平台适配</a></div>
           <div class="docs-nav-group"><p>维护</p><a href="#style">刷新上下文</a><a href="#uninstall">卸载</a><a href="#troubleshooting">故障排查</a></div>
           <div class="docs-nav-group"><p>链接</p><a href="./index.zh-CN.html">官网首页</a><a href="./docs.html">English Docs</a><a href="https://github.com/whitelonng/mancode/blob/main/README.md">GitHub README</a></div>
         </nav>
@@ -83,7 +83,7 @@
             <tr><td><code>--platform LIST</code></td><td>已经知道目标 Agent</td><td>安装 <code>claude-code</code>、<code>cursor</code>、<code>codex</code>、<code>copilot</code>、<code>zcode</code> 中的一个或多个。</td></tr>
             <tr><td><code>--empty</code></td><td>目录有意保持为空</td><td>无需先执行 <code>git init</code> 或创建 manifest，也能初始化通用项目。</td></tr>
             <tr><td><code>--team</code> / <code>--no-team</code></td><td>不采用自动判断结果</td><td>强制开启或关闭团队共享上下文。</td></tr>
-            <tr><td><code>--style NAME</code></td><td>已有明确的视觉偏好</td><td>保存为默认样式偏好。</td></tr>
+            <tr><td><code>--style NAME</code></td><td>显式使用 <code>--legacy</code> 初始化</td><td>保存旧版自由文本样式偏好。Continuity 项目改用带 revision 的 <code>mancode design</code> 策略。</td></tr>
             <tr><td><code>--lang en|zh-CN</code></td><td>需要稳定的生成语言</td><td>指定生成内容的语言。</td></tr>
           </tbody></table>
 
@@ -131,6 +131,35 @@
           <div class="docs-admonition"><strong>判断原则</strong><p>不要因为任务很长就默认使用 <code>/man</code>。当错误选择代价高、难以回滚，或事后很难审查时，再升级到它。</p></div>
         </section>
 
+        <section class="doc-section" id="design" data-searchable>
+          <h2>设置设计策略</h2>
+          <p>设计策略是面向 UI 任务的显式启用 Continuity 能力。<code>mancode init</code> 不会自动创建它；策略缺失、禁用或损坏时，设计上下文会安全降级为 <code>preserve</code>，不会阻塞普通编码或工作流恢复。</p>
+          <div class="mode-guide design-presets">
+            <article><small>改动最小</small><h3>preserve</h3><p>保留现有层级、布局、组件系统和交互模式，只完成任务真正要求的 UI 改动。</p></article>
+            <article><small>推荐默认</small><h3>refine</h3><p>改善层级、排版、间距、状态和响应式行为，但不改变产品结构。</p></article>
+            <article><small>显式确认</small><h3>experimental</h3><p>传入 <code>--confirm-experimental</code> 后允许一个更强、符合产品语境的构图与有目的动效，但不能扩大范围或虚构产品功能。</p></article>
+          </div>
+
+          <h3>实现前先选视觉方向</h3>
+          <p>新建 UI 或视觉重做时，如果用户尚未选定方向，Agent 会先给出 2–3 个差异明确、符合产品语境的方向，简述取舍并推荐一个，再等待用户选择。局部 UI 修复、既有设计系统内的改动，以及用户已经选定方向的任务不会被这一步打断。</p>
+          <div class="docs-note"><strong>产品语境决定强度</strong><p>品牌、活动、编辑、作品集和发布型页面可以强化首屏记忆点，并让一个视觉母题贯穿全页；任务型产品仍然把工作流清晰度放在视觉奇观之前。</p></div>
+
+          <h3>配置与检查</h3>
+          <div class="code-wrap"><pre><code><span class="command-prompt">$</span> mancode design status --json
+<span class="command-prompt">$</span> mancode design configure --expected-revision 0 --preset refine --icons lucide --emoji forbid-as-interface-icon --motion purposeful --browser-validation when-available
+<span class="command-prompt">$</span> mancode design context --json
+<span class="command-prompt">$</span> mancode design configure --expected-revision 1 --preset experimental --confirm-experimental
+<span class="command-prompt">$</span> mancode design disable --expected-revision 2</code></pre><button type="button" data-copy-code>复制</button></div>
+          <table class="docs-table"><thead><tr><th>控制项</th><th>可选值</th><th>边界</th></tr></thead><tbody>
+            <tr><td><code>--preset</code></td><td><code>preserve</code>、<code>refine</code>、<code>experimental</code></td><td>每次启用 <code>experimental</code> 都需要显式确认。</td></tr>
+            <tr><td><code>--icons</code></td><td><code>existing-first</code>、<code>lucide</code></td><td>选择 Lucide 不会自动安装依赖；依赖变更仍需任务明确授权。</td></tr>
+            <tr><td><code>--emoji</code></td><td><code>allow</code>、<code>forbid-as-interface-icon</code></td><td>严格模式禁止用表情符号代替界面图标。</td></tr>
+            <tr><td><code>--motion</code></td><td><code>minimal</code>、<code>purposeful</code></td><td>动效必须服务于层级、反馈或叙事，不能遮蔽核心工作流。</td></tr>
+            <tr><td><code>--browser-validation</code></td><td><code>off</code>、<code>when-available</code>、<code>required</code></td><td><code>required</code> 会在无法执行浏览器验证时形成硬质量门槛。</td></tr>
+          </tbody></table>
+          <div class="docs-admonition"><strong>任务范围保持不变</strong><p>任何设计 preset 都不授权新增功能、改变信息架构、静默安装依赖或重做无关界面。策略保存在 <code>.mancode/shared/context/design-policy.json</code>，应像其他仓库配置一样审查。</p></div>
+        </section>
+
         <section class="doc-section" id="modes" data-searchable>
           <h2>调用模式</h2>
           <p>模式名称是通用的，但调用方式取决于平台的扩展机制。下面这些内容应输入 Agent 对话框，而不是操作系统终端。<code>/mansolo</code> 或 <code>$mansolo</code> 会显式回到默认 <code>solo</code> 模式。</p>
@@ -168,7 +197,7 @@ $manteam</code></pre><button type="button" data-copy-code>复制</button></div><
           <h2>CLI 参考</h2>
           <p>CLI 负责安装适配器和强制执行持久化工作流状态。读取状态的命令应在已初始化项目中运行；非法状态转换会安全失败，不会静默篡改元数据。</p>
           <div class="command-list">
-            <article class="command-card"><header><h3>mancode init</h3><span>初始化</span></header><p>创建 <code>.mancode/</code>，识别项目，在适用时扫描样式 token，并安装平台适配器。</p><ul><li>选项：<code>--force</code>、<code>--yes</code>、<code>--team</code>、<code>--no-team</code>、<code>--style &lt;name&gt;</code>、<code>--platform &lt;list&gt;</code>、<code>--empty</code>、<code>--lang &lt;locale&gt;</code>。</li></ul></article>
+            <article class="command-card"><header><h3>mancode init</h3><span>初始化</span></header><p>创建 <code>.mancode/</code>，识别项目，在适用时扫描样式 token，并安装平台适配器。</p><ul><li>选项：<code>--force</code>、<code>--yes</code>、<code>--team</code>、<code>--no-team</code>、<code>--platform &lt;list&gt;</code>、<code>--empty</code>、<code>--lang &lt;locale&gt;</code>。<code>--style &lt;name&gt;</code> 仅适用于 legacy。</li></ul></article>
             <article class="command-card"><header><h3>mancode install [platform]</h3><span>适配器</span></header><p>初始化后通过 journaled upgrade 路径安装一个平台。</p><ul><li><code>--confirm --operation-id &lt;operationId&gt;</code> 和 active session 授权发布预览中的 managed 写入。</li><li><code>--minimal</code> 保留用于 legacy 兼容。</li></ul></article>
             <article class="command-card"><header><h3>mancode adapter status | upgrade</h3><span>修复</span></header><p>比较 managed-content digest，用 <code>--dry-run</code> 生成 staging，并且只用 <code>--confirm --operation-id &lt;operationId&gt;</code> 发布该次预览。</p></article>
             <article class="command-card"><header><h3>mancode project upgrade --policy 2</h3><span>策略</span></header><p>预览或提交项目的 Policy 2 默认值，不重写已有 workflow；提交需要预览返回的 operation ID 和 active session。</p></article>
@@ -176,6 +205,7 @@ $manteam</code></pre><button type="button" data-copy-code>复制</button></div><
             <article class="command-card"><header><h3>mancode list-platforms</h3><span>发现</span></header><p>列出当前 CLI 支持的平台，并标出项目中已经配置的平台。</p></article>
             <article class="command-card"><header><h3>mancode workflow &lt;subcommand&gt;</h3><span>治理</span></header><p>创建和校验 Continuity 需求、计划、验证证据、评审、修复与完成状态。</p><ul><li>使用 <code>list</code> 和 <code>show &lt;namespace:ULID&gt; [--json]</code> 检查。</li><li>使用 <code>context compact --dry-run</code> 检查可回收的运行时记录；Continuity workflow authority 不会被 <code>workflow clean</code> 删除。</li></ul></article>
             <article class="command-card"><header><h3>mancode manps [area]</h3><span>扫描</span></header><p>对 <code>all</code>、<code>deps</code>、<code>security</code>、<code>dead-code</code> 或 <code>config</code> 执行确定性健康扫描。</p><ul><li><code>--json</code> 输出机器可读结果。</li><li><code>--remediate</code> 显式进入修复路径；默认只扫描。</li></ul></article>
+            <article class="command-card"><header><h3>mancode design status | context | configure | disable</h3><span>设计</span></header><p>检查有效 UI 指导，或修改带 revision 的项目设计策略。配置必须传入 <code>--expected-revision &lt;n&gt;</code>；experimental 还需要 <code>--confirm-experimental</code>。</p></article>
             <article class="command-card"><header><h3>mancode refresh-project</h3><span>重扫项目</span></header><p>在加入 Git、manifest、框架或验证命令后刷新项目事实，并报告 stale adapter。</p></article>
             <article class="command-card"><header><h3>mancode refresh-style</h3><span>设计上下文</span></header><p>刷新项目画像和设计 token；adapter 修复先用 <code>mancode adapter upgrade --platform &lt;platform&gt; --dry-run</code> 预览。</p></article>
             <article class="command-card"><header><h3>mancode uninstall [platform]</h3><span>移除</span></header><p>移除一个 Continuity 适配器。Continuity 会保护权威数据不被批量删除；用 <code>context compact --dry-run</code> 检查保留候选。<code>--all</code> 只适用于 legacy 项目。</p></article>

--- a/website/index.html
+++ b/website/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="mancode gives AI coding agents the right level of engineering discipline for every task."
+      content="mancode gives AI coding agents the right engineering discipline and an explicit design direction for every task."
     />
     <meta name="theme-color" content="#08090a" />
     <meta property="og:title" content="mancode — Ship clean code, not AI bloat." />
@@ -37,6 +37,7 @@
       <nav class="main-nav" aria-label="Primary navigation">
         <a href="#modes">Modes</a>
         <a href="#workflow">Workflow</a>
+        <a href="#design">Design</a>
         <a href="#platforms">Platforms</a>
         <a href="#continuity">Continuity</a>
         <a href="./docs.html">Docs</a>
@@ -44,7 +45,7 @@
       </nav>
       <div class="header-actions">
         <button class="theme-toggle" type="button" data-theme-toggle aria-label="Switch to light theme" title="Switch theme">
-          <span aria-hidden="true">◐</span><b>Theme</b>
+          <span class="theme-toggle-icon" aria-hidden="true"><svg class="theme-icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.93 4.93l1.42 1.42M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"></path></svg><svg class="theme-icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 1 0 9 9 9 9 0 0 1-9-9Z"></path></svg></span><b>Theme</b>
         </button>
         <a class="language-link" href="./index.zh-CN.html" lang="zh-CN" aria-label="切换到中文">中</a>
         <a class="button button-small button-ghost header-cta" href="#install">Get mancode ↘</a>
@@ -314,9 +315,71 @@
         </div>
       </section>
 
+      <section class="design-section" id="design">
+        <div class="section-kicker reveal">
+          <span>05 / Design policy</span>
+          <span>Direction before decoration.</span>
+        </div>
+        <div class="design-lead reveal">
+          <div>
+            <p class="eyebrow">New in 0.5.0</p>
+            <h2>Choose the look.<br />Then make it real.</h2>
+          </div>
+          <div class="design-thesis">
+            <p>
+              A new UI or visual redesign no longer starts from one silent default. When the direction
+              is open, mancode asks the agent for 2–3 product-appropriate routes, the tradeoffs, and a
+              recommendation. You choose. Then it builds one coherent system.
+            </p>
+            <a href="./docs.html#design">Configure the policy <span aria-hidden="true">→</span></a>
+          </div>
+        </div>
+
+        <div class="design-board reveal">
+          <div class="direction-board" aria-label="Visual direction selection flow">
+            <header><span>UI brief / unselected</span><b>Decision required</b></header>
+            <div class="direction-prompt">
+              <small>Before implementation</small>
+              <strong>Present<br />2–3 routes.</strong>
+              <p>Distinct visual logic. Clear tradeoffs. One recommendation. No code until the direction is yours.</p>
+            </div>
+            <ol>
+              <li><b>01</b><span>Editorial precision</span><em>Quiet / typographic</em></li>
+              <li class="selected"><b>02</b><span>Technical theatre</span><em>Bold / kinetic</em></li>
+              <li><b>03</b><span>Product clarity</span><em>Dense / functional</em></li>
+            </ol>
+          </div>
+
+          <div class="preset-stack">
+            <article>
+              <div><small>Preset / 01</small><span>Safest</span></div>
+              <h3>preserve</h3>
+              <p>Keep the hierarchy, components, layout, and interaction patterns. Change only what the task requires.</p>
+            </article>
+            <article class="preset-featured">
+              <div><small>Preset / 02</small><span>Recommended</span></div>
+              <h3>refine</h3>
+              <p>Improve type, spacing, hierarchy, states, and responsive behavior without changing the product structure.</p>
+            </article>
+            <article>
+              <div><small>Preset / 03</small><span>Explicit opt-in</span></div>
+              <h3>experimental</h3>
+              <p>Allow one stronger composition and purposeful motion—after confirmation, inside the existing product scope.</p>
+            </article>
+          </div>
+        </div>
+
+        <div class="design-guardrails reveal" aria-label="Design policy guardrails">
+          <span><b>01</b> Existing system first</span>
+          <span><b>02</b> No product-scope expansion</span>
+          <span><b>03</b> No surprise dependencies</span>
+          <span><b>04</b> Browser validation when available</span>
+        </div>
+      </section>
+
       <section class="platforms-section" id="platforms">
         <div class="section-kicker reveal">
-          <span>05 / Adapters</span>
+          <span>06 / Adapters</span>
           <span>Keep your agent. Add the discipline.</span>
         </div>
         <div class="section-title-row platform-title reveal">
@@ -351,7 +414,7 @@
 
       <section class="platforms-section" id="continuity">
         <div class="section-kicker reveal">
-          <span>06 / Cross-session continuity</span>
+          <span>07 / Cross-session continuity</span>
           <span>Change windows without losing the task.</span>
         </div>
         <div class="section-title-row platform-title reveal">
@@ -384,7 +447,7 @@
 
       <section class="install-section section-dark" id="install">
         <div class="section-kicker reveal">
-          <span>07 / Quick start</span>
+          <span>08 / Quick start</span>
           <span>One install. One init. Keep coding.</span>
         </div>
         <div class="install-grid">

--- a/website/index.zh-CN.html
+++ b/website/index.zh-CN.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="mancode：给 AI 编码 Agent 恰到好处的工程纪律。" />
+    <meta name="description" content="mancode：给 AI 编码 Agent 恰到好处的工程纪律，以及明确可选的视觉方向。" />
     <meta name="theme-color" content="#08090a" />
     <link rel="icon" href="./logo.png" />
     <link rel="stylesheet" href="./styles.css" />
@@ -20,8 +20,8 @@
     <a class="skip-link" href="#main">跳到正文</a><div class="noise" aria-hidden="true"></div>
     <header class="site-header">
       <a class="brand" href="#top" aria-label="mancode 首页"><img src="./logo.png" alt="" /><span>mancode</span><i aria-hidden="true"></i></a>
-      <nav class="main-nav" aria-label="主导航"><a href="#modes">模式</a><a href="#workflow">工作流</a><a href="#platforms">平台</a><a href="#continuity">跨会话</a><a href="./docs.zh-CN.html">文档</a><a href="https://github.com/whitelonng/mancode">GitHub</a></nav>
-      <div class="header-actions"><button class="theme-toggle" type="button" data-theme-toggle aria-label="切换到白色主题" title="切换主题"><span aria-hidden="true">◐</span><b>主题</b></button><a class="language-link" href="./index.html" lang="en" aria-label="Switch to English">EN</a><a class="button button-small button-ghost header-cta" href="#install">开始使用 ↘</a></div>
+      <nav class="main-nav" aria-label="主导航"><a href="#modes">模式</a><a href="#workflow">工作流</a><a href="#design">审美</a><a href="#platforms">平台</a><a href="#continuity">跨会话</a><a href="./docs.zh-CN.html">文档</a><a href="https://github.com/whitelonng/mancode">GitHub</a></nav>
+      <div class="header-actions"><button class="theme-toggle" type="button" data-theme-toggle aria-label="切换到白色主题" title="切换主题"><span class="theme-toggle-icon" aria-hidden="true"><svg class="theme-icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.93 4.93l1.42 1.42M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"></path></svg><svg class="theme-icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 1 0 9 9 9 9 0 0 1-9-9Z"></path></svg></span><b>主题</b></button><a class="language-link" href="./index.html" lang="en" aria-label="Switch to English">EN</a><a class="button button-small button-ghost header-cta" href="#install">开始使用 ↘</a></div>
     </header>
 
     <main id="main">
@@ -67,10 +67,43 @@
         </div>
       </section>
 
-      <section class="platforms-section" id="platforms"><div class="section-kicker reveal"><span>05 / 适配器</span><span>保留你的 Agent，加入纪律。</span></div><div class="section-title-row platform-title reveal"><h2>一套战术。<br />你的工具。</h2><p>mancode 是工作流层，不是新的编码 Agent。Claude Code 获得最完整的原生集成；其他工具获得持久 rules、skills 或 instruction 文件。</p></div><div class="platform-table reveal" role="table"><div class="platform-row platform-head" role="row"><span role="columnheader">平台</span><span role="columnheader">适配方式</span><span role="columnheader">级别</span></div><div class="platform-row" role="row"><strong role="cell">Claude Code</strong><span role="cell">Hooks · skills · subagents</span><em role="cell">完整集成</em></div><div class="platform-row" role="row"><strong role="cell">Cursor</strong><span role="cell">项目 rules · commands</span><em role="cell">适配器</em></div><div class="platform-row" role="row"><strong role="cell">Codex</strong><span role="cell">AGENTS.md · 项目 skills</span><em role="cell">适配器</em></div><div class="platform-row" role="row"><strong role="cell">GitHub Copilot</strong><span role="cell">仓库 instructions · prompts</span><em role="cell">适配器</em></div><div class="platform-row" role="row"><strong role="cell">ZCode</strong><span role="cell">AGENTS.md · 项目 skills</span><em role="cell">预览适配器</em></div></div></section>
+      <section class="design-section" id="design">
+        <div class="section-kicker reveal"><span>05 / 设计策略</span><span>先选方向，再谈装饰。</span></div>
+        <div class="design-lead reveal">
+          <div><p class="eyebrow">0.5.0 新能力</p><h2>方向你来选。<br />效果交给它。</h2></div>
+          <div class="design-thesis">
+            <p>新建 UI 或视觉重做，不再由 Agent 默默套用唯一默认风格。方向尚未确定时，mancode 会先给出 2–3 个符合产品语境的方案、简明取舍和一个推荐；你选定后，它再把一个视觉系统做完整。</p>
+            <a href="./docs.zh-CN.html#design">配置设计策略 <span aria-hidden="true">→</span></a>
+          </div>
+        </div>
+
+        <div class="design-board reveal">
+          <div class="direction-board" aria-label="视觉方向选择流程">
+            <header><span>UI 需求 / 尚未选定</span><b>等待决策</b></header>
+            <div class="direction-prompt"><small>开始实现之前</small><strong>先给出<br />2–3 个方向。</strong><p>视觉逻辑要有差异，取舍要说清楚，并给出一个推荐。在方向属于你之前，不急着写代码。</p></div>
+            <ol>
+              <li><b>01</b><span>编辑式精度</span><em>克制 / 排版驱动</em></li>
+              <li class="selected"><b>02</b><span>技术剧场</span><em>强烈 / 动态叙事</em></li>
+              <li><b>03</b><span>产品清晰度</span><em>紧凑 / 功能优先</em></li>
+            </ol>
+          </div>
+
+          <div class="preset-stack">
+            <article><div><small>策略 / 01</small><span>最稳妥</span></div><h3>preserve</h3><p>保留现有层级、组件、布局和交互模式，只完成任务真正要求的 UI 改动。</p></article>
+            <article class="preset-featured"><div><small>策略 / 02</small><span>推荐</span></div><h3>refine</h3><p>改善排版、间距、层级、状态和响应式行为，但不改变产品结构。</p></article>
+            <article><div><small>策略 / 03</small><span>显式开启</span></div><h3>experimental</h3><p>确认后允许更强的构图与有目的的动效，仍然不能突破既有产品范围。</p></article>
+          </div>
+        </div>
+
+        <div class="design-guardrails reveal" aria-label="设计策略边界">
+          <span><b>01</b> 现有设计系统优先</span><span><b>02</b> 不扩大产品范围</span><span><b>03</b> 不偷加依赖</span><span><b>04</b> 条件允许时浏览器验证</span>
+        </div>
+      </section>
+
+      <section class="platforms-section" id="platforms"><div class="section-kicker reveal"><span>06 / 适配器</span><span>保留你的 Agent，加入纪律。</span></div><div class="section-title-row platform-title reveal"><h2>一套战术。<br />你的工具。</h2><p>mancode 是工作流层，不是新的编码 Agent。Claude Code 获得最完整的原生集成；其他工具获得持久 rules、skills 或 instruction 文件。</p></div><div class="platform-table reveal" role="table"><div class="platform-row platform-head" role="row"><span role="columnheader">平台</span><span role="columnheader">适配方式</span><span role="columnheader">级别</span></div><div class="platform-row" role="row"><strong role="cell">Claude Code</strong><span role="cell">Hooks · skills · subagents</span><em role="cell">完整集成</em></div><div class="platform-row" role="row"><strong role="cell">Cursor</strong><span role="cell">项目 rules · commands</span><em role="cell">适配器</em></div><div class="platform-row" role="row"><strong role="cell">Codex</strong><span role="cell">AGENTS.md · 项目 skills</span><em role="cell">适配器</em></div><div class="platform-row" role="row"><strong role="cell">GitHub Copilot</strong><span role="cell">仓库 instructions · prompts</span><em role="cell">适配器</em></div><div class="platform-row" role="row"><strong role="cell">ZCode</strong><span role="cell">AGENTS.md · 项目 skills</span><em role="cell">预览适配器</em></div></div></section>
 
       <section class="platforms-section" id="continuity">
-        <div class="section-kicker reveal"><span>06 / 跨会话续接</span><span>换窗口，不丢任务脉络。</span></div>
+        <div class="section-kicker reveal"><span>07 / 跨会话续接</span><span>换窗口，不丢任务脉络。</span></div>
         <div class="section-title-row platform-title reveal">
           <h2>一项任务。<br />下个会话继续。</h2>
           <p>mancode 把目标、需求、计划、检查结果和交接信息保存在稳定 TaskRef 下。新聊天窗口或 CLI session 可以恢复这项任务，只加载当前目的需要的 Context Pack，不依赖旧窗口一直打开。</p>
@@ -84,7 +117,7 @@
         </div>
       </section>
 
-      <section class="install-section section-dark" id="install"><div class="section-kicker reveal"><span>07 / 快速开始</span><span>安装一次，初始化一次，继续编码。</span></div><div class="install-grid"><div class="install-copy reveal"><p class="eyebrow">准备上场</p><h2>把 mancode<br />放进轮换。</h2><p>不需要账户、Dashboard、API Key 或新编辑器。原生支持 Windows CMD、PowerShell、Git Bash、macOS 与 Linux。</p><a class="button button-solid" href="./docs.zh-CN.html">阅读完整文档 ↗</a></div><div class="steps-terminal reveal"><div class="terminal-command"><span>01 / 安装</span><code>npm install -g mancode</code><button type="button" data-copy="npm install -g mancode">复制</button></div><div class="terminal-command"><span>02 / 进入项目</span><code>cd your-project</code><button type="button" data-copy="cd your-project">复制</button></div><div class="terminal-command"><span>03 / 初始化</span><code>mancode init</code><button type="button" data-copy="mancode init">复制</button></div><div class="terminal-ready"><i></i><span>solo 模式已就绪</span><b>00:03</b></div></div></div></section>
+      <section class="install-section section-dark" id="install"><div class="section-kicker reveal"><span>08 / 快速开始</span><span>安装一次，初始化一次，继续编码。</span></div><div class="install-grid"><div class="install-copy reveal"><p class="eyebrow">准备上场</p><h2>把 mancode<br />放进轮换。</h2><p>不需要账户、Dashboard、API Key 或新编辑器。原生支持 Windows CMD、PowerShell、Git Bash、macOS 与 Linux。</p><a class="button button-solid" href="./docs.zh-CN.html">阅读完整文档 ↗</a></div><div class="steps-terminal reveal"><div class="terminal-command"><span>01 / 安装</span><code>npm install -g mancode</code><button type="button" data-copy="npm install -g mancode">复制</button></div><div class="terminal-command"><span>02 / 进入项目</span><code>cd your-project</code><button type="button" data-copy="cd your-project">复制</button></div><div class="terminal-command"><span>03 / 初始化</span><code>mancode init</code><button type="button" data-copy="mancode init">复制</button></div><div class="terminal-ready"><i></i><span>solo 模式已就绪</span><b>00:03</b></div></div></div></section>
 
       <section class="final-cta"><div class="final-cta-mark" aria-hidden="true">M</div><p class="reveal">简单任务少一点仪式。<br />关键任务多一点纪律。</p><h2 class="reveal">别再替 AI<br />收拾臃肿。</h2><div class="final-actions reveal"><div class="command-bar command-light"><code><span>&gt;</span> npm install -g mancode</code><button type="button" data-copy="npm install -g mancode">复制</button></div><a class="button button-dark" href="https://github.com/whitelonng/mancode">GitHub 上查看 ↗</a></div></section>
     </main>

--- a/website/site.js
+++ b/website/site.js
@@ -16,7 +16,6 @@ function updateThemeToggle(theme) {
       : "Switch to light theme";
   themeToggle.setAttribute("aria-label", label);
   themeToggle.title = label;
-  themeToggle.querySelector("span").textContent = isLight ? "◑" : "◐";
 }
 
 updateThemeToggle(document.documentElement.dataset.theme || "dark");

--- a/website/styles.css
+++ b/website/styles.css
@@ -614,6 +614,7 @@ h1 .orange {
 .modes-section,
 .workflow-section,
 .awareness-section,
+.design-section,
 .platforms-section,
 .install-section {
   padding: 0 var(--gutter) clamp(92px, 11vw, 160px);
@@ -665,6 +666,7 @@ h1 .orange {
 .section-title-row h2,
 .workflow-lead h2,
 .awareness-copy h2,
+.design-lead h2,
 .install-copy h2,
 .final-cta h2 {
   margin-bottom: 0;
@@ -1258,6 +1260,273 @@ h1 .orange {
   color: var(--lime);
 }
 
+.design-section {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 1px 1px, rgba(8, 9, 10, 0.22) 1px, transparent 0) 0 0 / 28px 28px,
+    var(--orange);
+  color: #08090a;
+}
+
+.design-section::before {
+  position: absolute;
+  top: 8%;
+  right: -9%;
+  width: clamp(260px, 38vw, 560px);
+  aspect-ratio: 1;
+  border: 1px solid rgba(8, 9, 10, 0.24);
+  border-radius: 50%;
+  content: "";
+  box-shadow:
+    0 0 0 42px rgba(8, 9, 10, 0.035),
+    0 0 0 84px rgba(8, 9, 10, 0.025);
+  pointer-events: none;
+}
+
+.design-section > * {
+  position: relative;
+  z-index: 1;
+}
+
+.design-section .section-kicker {
+  border-color: rgba(8, 9, 10, 0.72);
+}
+
+.design-lead {
+  display: grid;
+  grid-template-columns: 1.3fr 0.7fr;
+  align-items: end;
+  gap: clamp(48px, 8vw, 112px);
+  padding: clamp(70px, 8vw, 118px) 0 clamp(58px, 7vw, 96px);
+}
+
+.design-lead .eyebrow {
+  color: #08090a;
+}
+
+.design-lead h2 {
+  margin: 18px 0 0;
+  max-width: 920px;
+  font-size: clamp(64px, 8.4vw, 124px);
+}
+
+.design-thesis p {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.85;
+}
+
+.design-thesis a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 28px;
+  width: 100%;
+  margin-top: 30px;
+  padding: 17px 0;
+  border-top: 1px solid #08090a;
+  border-bottom: 1px solid #08090a;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  transition: padding 180ms ease;
+}
+
+.design-thesis a:hover {
+  padding-inline: 12px;
+}
+
+.design-thesis a span {
+  font-size: 20px;
+}
+
+.design-board {
+  display: grid;
+  grid-template-columns: minmax(0, 1.06fr) minmax(360px, 0.94fr);
+  border: 1px solid #08090a;
+  box-shadow: 18px 18px 0 rgba(8, 9, 10, 0.15);
+}
+
+.direction-board {
+  min-width: 0;
+  background: #08090a;
+  color: #f4f1e9;
+}
+
+.direction-board header,
+.preset-stack article > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  min-height: 48px;
+  padding: 0 20px;
+  border-bottom: 1px solid rgba(244, 241, 233, 0.18);
+  font-size: 8px;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.direction-board header b {
+  color: var(--lime);
+  font-size: inherit;
+}
+
+.direction-prompt {
+  padding: clamp(36px, 5vw, 72px);
+  background:
+    linear-gradient(rgba(69, 216, 238, 0.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(69, 216, 238, 0.055) 1px, transparent 1px);
+  background-size: 42px 42px;
+}
+
+.direction-prompt small {
+  color: var(--cyan);
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.direction-prompt strong {
+  display: block;
+  margin-top: 22px;
+  font-family: var(--display);
+  font-size: clamp(58px, 7vw, 96px);
+  font-weight: 900;
+  line-height: 0.82;
+  letter-spacing: -0.035em;
+  text-transform: uppercase;
+}
+
+.direction-prompt p {
+  max-width: 520px;
+  margin: 30px 0 0;
+  color: #92989d;
+  font-size: 10px;
+  line-height: 1.75;
+}
+
+.direction-board ol {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid rgba(244, 241, 233, 0.18);
+  list-style: none;
+}
+
+.direction-board li {
+  display: grid;
+  grid-template-columns: 42px 1fr auto;
+  align-items: center;
+  min-height: 67px;
+  padding: 0 20px;
+  border-bottom: 1px solid rgba(244, 241, 233, 0.14);
+  color: #92989d;
+  font-size: 10px;
+}
+
+.direction-board li:last-child {
+  border-bottom: 0;
+}
+
+.direction-board li b,
+.direction-board li em {
+  font-size: 8px;
+  font-style: normal;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.direction-board li.selected {
+  background: var(--cyan);
+  color: #08090a;
+  box-shadow: inset 5px 0 0 var(--lime);
+}
+
+.preset-stack {
+  display: grid;
+  grid-template-rows: repeat(3, 1fr);
+  border-left: 1px solid #08090a;
+}
+
+.preset-stack article {
+  min-height: 230px;
+  padding: 0 clamp(24px, 3.5vw, 46px) clamp(30px, 4vw, 48px);
+  border-bottom: 1px solid #08090a;
+  background: #f4f1e9;
+}
+
+.preset-stack article:last-child {
+  border-bottom: 0;
+}
+
+.preset-stack article > div {
+  margin: 0 clamp(-46px, -3.5vw, -24px) clamp(26px, 3vw, 40px);
+  padding-inline: clamp(24px, 3.5vw, 46px);
+  border-color: rgba(8, 9, 10, 0.2);
+}
+
+.preset-stack article > div span {
+  color: #656a6e;
+}
+
+.preset-stack h3 {
+  margin: 0;
+  font-family: var(--display);
+  font-size: clamp(44px, 5vw, 74px);
+  line-height: 0.9;
+  letter-spacing: -0.025em;
+  text-transform: uppercase;
+}
+
+.preset-stack p {
+  max-width: 520px;
+  margin: 22px 0 0;
+  color: #5a6064;
+  font-size: 10px;
+  line-height: 1.75;
+}
+
+.preset-stack .preset-featured {
+  background: #111417;
+  color: #f4f1e9;
+}
+
+.preset-stack .preset-featured > div {
+  border-color: rgba(244, 241, 233, 0.18);
+}
+
+.preset-stack .preset-featured > div span,
+.preset-stack .preset-featured p {
+  color: #c8ff4a;
+}
+
+.design-guardrails {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin-top: 52px;
+  border-top: 1px solid #08090a;
+  border-left: 1px solid #08090a;
+}
+
+.design-guardrails span {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  min-height: 128px;
+  padding: 20px;
+  border-right: 1px solid #08090a;
+  border-bottom: 1px solid #08090a;
+  font-size: 9px;
+  line-height: 1.5;
+  text-transform: uppercase;
+}
+
+.design-guardrails b {
+  font-size: 20px;
+}
+
 .platform-title {
   grid-template-columns: 1.1fr 0.9fr;
 }
@@ -1618,6 +1887,7 @@ h1 .orange {
   .section-title-row,
   .workflow-lead,
   .awareness-grid,
+  .design-lead,
   .install-grid {
     gap: 48px;
   }
@@ -1643,6 +1913,27 @@ h1 .orange {
 
   .workflow-grid li {
     min-height: 190px;
+  }
+
+  .design-board {
+    grid-template-columns: 1fr;
+  }
+
+  .preset-stack {
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: none;
+    border-top: 1px solid #08090a;
+    border-left: 0;
+  }
+
+  .preset-stack article {
+    min-height: 275px;
+    border-right: 1px solid #08090a;
+    border-bottom: 0;
+  }
+
+  .preset-stack article:last-child {
+    border-right: 0;
   }
 
   .site-footer {
@@ -1743,6 +2034,7 @@ h1 .orange {
   .section-title-row,
   .workflow-lead,
   .awareness-grid,
+  .design-lead,
   .install-grid {
     grid-template-columns: 1fr;
   }
@@ -1755,8 +2047,43 @@ h1 .orange {
   .section-title-row h2,
   .workflow-lead h2,
   .awareness-copy h2,
+  .design-lead h2,
   .install-copy h2 {
     font-size: clamp(58px, 18vw, 82px);
+  }
+
+  .design-lead {
+    gap: 38px;
+  }
+
+  .design-board {
+    box-shadow: 10px 10px 0 rgba(8, 9, 10, 0.15);
+  }
+
+  .direction-prompt {
+    padding: 38px 26px;
+  }
+
+  .direction-board li {
+    grid-template-columns: 34px 1fr;
+  }
+
+  .direction-board li em {
+    display: none;
+  }
+
+  .preset-stack {
+    grid-template-columns: 1fr;
+  }
+
+  .preset-stack article {
+    min-height: 0;
+    border-right: 0;
+    border-bottom: 1px solid #08090a;
+  }
+
+  .design-guardrails {
+    grid-template-columns: 1fr 1fr;
   }
 
   .versus-grid {
@@ -2038,7 +2365,31 @@ h1 .orange {
 
 .theme-toggle span {
   color: var(--cyan);
-  font-size: 13px;
+}
+
+.theme-toggle-icon {
+  display: inline-grid;
+  width: 15px;
+  height: 15px;
+  place-items: center;
+}
+
+.theme-toggle-icon svg {
+  display: none;
+  width: 15px;
+  height: 15px;
+}
+
+.theme-icon-sun {
+  display: block !important;
+}
+
+html[data-theme="light"] .theme-icon-sun {
+  display: none !important;
+}
+
+html[data-theme="light"] .theme-icon-moon {
+  display: block !important;
 }
 
 .language-link {


### PR DESCRIPTION
## What changed

- add a high-contrast 0.5.0 design-policy section to both landing pages
- explain the 2–3 direction decision rule, preserve/refine/experimental presets, and scope guardrails
- add a complete bilingual `mancode design` documentation section and correct legacy-only `--style` guidance
- replace the theme glyph with inline Lucide sun and moon icons
- update website contract tests for the new content and section order

## Why

The public website showed version 0.5.0 but did not explain the release's primary UI-design capability. Users could not discover how direction selection works, how to configure the policy, or which safety boundaries remain in force.

## User impact

Visitors can now understand and configure the design policy from the official site without consulting repository internals. The original opening section and established brand system remain intact.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test -- --silent` (122 files, 858 tests)
- website contract tests (8 passed)
- Playwright headless checks at 1440px and 390px for both languages, both docs layouts, theme icons, and horizontal overflow
- `git diff --check`
