### PR TITLE
test: isolate platform-hint env vars in init onboarding tests

### DIFF
--- a/tests/init-onboarding.test.ts
+++ b/tests/init-onboarding.test.ts
@@ -8,7 +8,15 @@ import {
 } from 'node:fs/promises';
 import os, { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import {
   EXIT_INIT_FAILED,
   EXIT_NOT_A_PROJECT_DIR,
@@ -24,11 +32,26 @@ import type { InitPrompter } from '../src/system/init-onboarding.js';
 import {
   detectInitLocale,
   detectNativeSystemLocale,
+  detectPlatformHints,
   parsePlatformSelection,
 } from '../src/system/init-onboarding.js';
 
+const PLATFORM_HINT_ENV_VARS = [
+  'CLAUDECODE',
+  'CLAUDE_CODE',
+  'CODEX_HOME',
+  'CURSOR_TRACE_ID',
+  'COPILOT_AGENT',
+  'GITHUB_COPILOT',
+] as const;
+
 describe('init onboarding', () => {
   const dirs: string[] = [];
+
+  beforeAll(() => {
+    for (const name of PLATFORM_HINT_ENV_VARS) vi.stubEnv(name, undefined);
+  });
+  afterAll(() => vi.unstubAllEnvs());
 
   afterEach(async () => {
     await Promise.all(
@@ -143,6 +166,19 @@ describe('init onboarding', () => {
       'qoder',
     ]);
     expect(parsePlatformSelection('unknown')).toBeNull();
+  });
+
+  it('treats ambient CLAUDECODE and CLAUDE_CODE as intentional claude-code hints', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-hints-'));
+    dirs.push(dir);
+
+    expect(await detectPlatformHints(dir, { CLAUDECODE: '1' })).toContain(
+      'claude-code',
+    );
+    expect(await detectPlatformHints(dir, { CLAUDE_CODE: 'x' })).toContain(
+      'claude-code',
+    );
+    expect(await detectPlatformHints(dir, {})).toEqual([]);
   });
 
   it('initializes a safe empty directory after an explicit confirmation', async () => {

--- a/tests/v3-init-command.test.ts
+++ b/tests/v3-init-command.test.ts
@@ -1,7 +1,16 @@
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import {
   EXIT_ALREADY_INITIALIZED,
   EXIT_INIT_FAILED,
@@ -14,7 +23,21 @@ import { parseSchemaManifest } from '../src/context/manifest.js';
 import { runtimeCheckoutRecordPath } from '../src/runtime/project-runtime.js';
 import { VERSION } from '../src/version.js';
 
+const PLATFORM_HINT_ENV_VARS = [
+  'CLAUDECODE',
+  'CLAUDE_CODE',
+  'CODEX_HOME',
+  'CURSOR_TRACE_ID',
+  'COPILOT_AGENT',
+  'GITHUB_COPILOT',
+] as const;
+
 describe('journaled V3 init command', () => {
+  beforeAll(() => {
+    for (const name of PLATFORM_HINT_ENV_VARS) vi.stubEnv(name, undefined);
+  });
+  afterAll(() => vi.unstubAllEnvs());
+
   let root: string;
 
   beforeEach(async () => {
@@ -234,5 +257,39 @@ describe('journaled V3 init command', () => {
     await expect(
       readFile(path.join(root, '.mancode', 'config.json'), 'utf8'),
     ).resolves.toBe('{}\n');
+  });
+
+  it('requires an explicit platform for a non-interactive V3 CLI with no detected hints', async () => {
+    await mkdir(path.join(root, '.git'));
+
+    expect(await init(root, { fromCli: true, interactive: false })).toBe(
+      EXIT_INIT_FAILED,
+    );
+    await expect(
+      readFile(path.join(root, '.mancode', 'schema.json'), 'utf8'),
+    ).rejects.toThrow();
+  });
+
+  it('auto-selects a single detected platform hint on the V3 CLI path', async () => {
+    await mkdir(path.join(root, '.git'));
+    await mkdir(path.join(root, '.cursor'));
+
+    expect(await init(root, { fromCli: true, interactive: false })).toBe(
+      EXIT_OK,
+    );
+    await expect(
+      readFile(path.join(root, '.cursor', 'commands', 'man.md'), 'utf8'),
+    ).resolves.toContain('mancode workflow create man');
+  });
+
+  it('keeps --yes from silently choosing an adapter on a non-interactive V3 CLI', async () => {
+    await mkdir(path.join(root, '.git'));
+
+    expect(
+      await init(root, { fromCli: true, interactive: false, yes: true }),
+    ).toBe(EXIT_INIT_FAILED);
+    await expect(
+      readFile(path.join(root, '.mancode', 'schema.json'), 'utf8'),
+    ).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- 修复 3 个测试在 Claude Code 会话内（`CLAUDECODE=1`）失败的问题：Claude Code runtime 设置的环境变量泄漏进平台检测（`detectPlatformHints`），破坏测试封闭性（此前基线 884/887）。
- 在 `tests/init-onboarding.test.ts` 与 `tests/v3-init-command.test.ts` 顶部用 `vi.stubEnv` 屏蔽 6 个平台提示变量，`afterAll` 恢复，文件级隔离（vitest `isolate: true`，无跨文件泄漏）。
- 新增 4 个契约锚定用例：legacy 正向固定（`CLAUDECODE`/`CLAUDE_CODE` → claude-code hint）、V3 非交互无提示失败、V3 非交互 `--yes` 无提示失败、V3 单提示自动选择。
- 无产品代码改动（+95/-2，仅测试）。

## Test plan

| 环境 | 结果 |
|---|---|
| 干净环境（`env -u CLAUDECODE`） | 目标 2 文件 37/37 |
| 污染全部 6 提示变量 | 目标 2 文件 37/37 |
| Claude Code 会话内（`CLAUDECODE=1`） | 全量 125 文件 891/891 |
| `biome check tests/`、`tsc --noEmit`、`git diff --check` | 全部通过 |