### PR TITLE
test: stabilize status terminology contract

### DIFF
--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -179,7 +179,8 @@ describe('mancode status', () => {
     expect(output).toContain(`mancode Continuity v${VERSION}`);
     expect(output).toContain('Activation:  active');
     expect(output).toContain('mancode adapter status:');
-    expect(output).not.toContain('V3');
+    expect(output).not.toContain('(V3 authority)');
+    expect(output).not.toContain('V3 adapter status:');
     expect(output).not.toContain('v3_active');
   });
 


### PR DESCRIPTION
Fixes a flaky status terminology assertion that scanned random activation identifiers for the substring V3. The contract now rejects the exact legacy public labels instead. Verified with the status suite on Node 22 and Node 24, plus the full 126-file / 916-test coverage gate on Node 22.