### PR TITLE
release: mancode 0.6.1

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="./LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg?style=flat-square" alt="License: AGPL-3.0" /></a>
   <a href="https://www.npmjs.com/package/mancode"><img src="https://img.shields.io/npm/v/mancode?style=flat-square" alt="npm version" /></a>
-  <img src="https://img.shields.io/badge/status-Continuity%20v0.6.0-2f855a?style=flat-square" alt="Status: mancode Continuity v0.6.0" />
+  <img src="https://img.shields.io/badge/status-Continuity%20v0.6.1-2f855a?style=flat-square" alt="Status: mancode Continuity v0.6.1" />
   <img src="https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Cursor%20%7C%20Codex%20%7C%20Copilot%20%7C%20ZCode%20%7C%20Kimi%20Code%20%7C%20Qoder%20%7C%20DeepSeek%20Harness-5865F2?style=flat-square" alt="Platforms: Claude Code, Cursor, Codex in ChatGPT desktop and CLI, GitHub Copilot, ZCode, Kimi Code, Qoder, DeepSeek Harness" />
 </p>
 
@@ -155,7 +155,7 @@ the quality gate for models that need explicit review structure.
 
 ## Installation
 
-**Status**: mancode Continuity v0.6.0. Claude Code, Cursor, Codex in the ChatGPT
+**Status**: mancode Continuity v0.6.1. Claude Code, Cursor, Codex in the ChatGPT
 desktop app and CLI, GitHub Copilot, ZCode, Kimi Code, Qoder, and DeepSeek Harness adapters are included.
 
 Requires Node.js 22 or newer. macOS, Linux, Windows CMD, PowerShell, and Git Bash
@@ -176,10 +176,14 @@ mancode init --platform all
 
 `init` guides you through the agent choice and marks a detected agent as a hint;
 it never silently installs every adapter. Choose one or more adapters, or choose
-**All platforms**. In a brand-new empty folder it asks whether to initialize a
-generic project, so users do not need to know `git init` or `npm init -y` first.
-Adding Git or a manifest later is safe; run `mancode refresh-project` to update
-the detected project facts and installed static adapters.
+**All platforms**. Git is not an initialization prerequisite. A non-empty
+directory is recognized as a project when its top level contains a common
+manifest, source file (such as `.html`, `.js`, `.py`, or `.go`), or source root
+(such as `src/`, `app/`, or `web/`). Detection intentionally inspects only the
+current directory's top level, so a nested project does not make an asset-pack
+parent directory look like a project. In a brand-new empty folder, `init` asks
+whether to initialize a generic project. Run `mancode refresh-project` after
+adding Git, manifests, source, dependencies, or validation commands.
 
 After initialization, keep using your coding agent normally. `solo` mode runs by
 default: practice day, no ceremony. Use `/man` when a task needs planning,
@@ -530,7 +534,7 @@ platform bootstrap and original mode entry. Coding agents should combine
 Simplified output:
 
 ```text
-mancode v0.6.0
+mancode v0.6.1
 
 Project:     my-app
 Runtime:     ready
@@ -702,11 +706,16 @@ refreshing project facts does not require reinstalling them.
 
 ### `mancode init` says "not a project directory"
 
-In an interactive terminal, an empty directory is offered as a new generic
-project. No Git or package command is required. To protect existing files,
-non-empty unrecognized directories are rejected; enter the project directory
-instead. For scripts, use `mancode init --empty --platform <platform>` only for
-a deliberately empty directory.
+Git is not required. mancode accepts common manifests, top-level source files
+(such as `.html`, `.js`, `.py`, or `.go`), and source roots (such as `src/`,
+`app/`, or `web/`) as project evidence. It inspects only the current directory's
+top level, so enter the actual source directory instead of an asset-pack parent.
+
+An empty directory is offered as a new generic project in an interactive
+terminal. To protect existing files, a non-empty directory containing only
+assets or documentation and no project evidence is still rejected. For scripts,
+use `mancode init --empty --platform <platform>` only for a deliberately empty
+directory. Home and filesystem root directories can never be initialized.
 
 ### Claude Code hooks not triggering
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="./LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg?style=flat-square" alt="许可证：AGPL-3.0" /></a>
   <a href="https://www.npmjs.com/package/mancode"><img src="https://img.shields.io/npm/v/mancode?style=flat-square" alt="npm 版本" /></a>
-  <img src="https://img.shields.io/badge/status-Continuity%20v0.6.0-2f855a?style=flat-square" alt="状态：mancode Continuity v0.6.0" />
+  <img src="https://img.shields.io/badge/status-Continuity%20v0.6.1-2f855a?style=flat-square" alt="状态：mancode Continuity v0.6.1" />
   <img src="https://img.shields.io/badge/platforms-Claude%20Code%20%7C%20Cursor%20%7C%20Codex%20%7C%20Copilot%20%7C%20ZCode%20%7C%20Kimi%20Code%20%7C%20Qoder%20%7C%20DeepSeek%20Harness-5865F2?style=flat-square" alt="平台：Claude Code、Cursor、ChatGPT 桌面端 Codex、Codex CLI、GitHub Copilot、ZCode、Kimi Code、Qoder、DeepSeek Harness" />
 </p>
 
@@ -124,7 +124,7 @@ mancode 不是 Claude Code、Cursor、Codex 或 Copilot 的替代品。它是在
 
 ## 安装方法
 
-**状态**：mancode Continuity v0.6.0。Claude Code、Cursor、ChatGPT 桌面端中的
+**状态**：mancode Continuity v0.6.1。Claude Code、Cursor、ChatGPT 桌面端中的
 Codex、Codex CLI、GitHub Copilot、ZCode、Kimi Code、Qoder 和 DeepSeek Harness adapter 均已接入。
 
 需要 Node.js 22 或更高版本。原生支持 macOS、Linux、Windows CMD、
@@ -143,8 +143,9 @@ mancode init --platform all
 ```
 
 `init` 会引导选择 Agent，并把检测到的 Agent 仅作为提示；不会悄悄安装全部适配器。
-可以选择一个、多个或“全部平台”。全新空目录会询问是否初始化为通用项目，因此用户不必
-先知道 `git init` 或 `npm init -y`。之后再加入 Git 或项目 manifest 也安全，执行
+可以选择一个、多个或“全部平台”。Git 不是初始化前提；已有 manifest、顶层源码文件或
+常见源码目录的项目可直接初始化。全新空目录会询问是否初始化为通用项目，因此用户不必
+先知道 `git init` 或 `npm init -y`。之后再加入 Git 或项目源码也安全，执行
 `mancode refresh-project` 即可刷新项目事实和已安装的静态适配器。
 
 初始化后，继续正常使用你的编码代理。`solo` 默认自动生效：日常训练，零仪式感。遇到需要
@@ -472,7 +473,7 @@ transport 和各平台 bootstrap/原 mode 入口的实际就绪状态。编码 A
 以下是简化输出示例：
 
 ```text
-mancode v0.6.0
+mancode v0.6.1
 
 Project:     my-app
 Runtime:     ready
@@ -609,9 +610,13 @@ Monorepo 可显式选择一个仓库内 UI 根目录，例如 `mancode refresh-s
 
 ### `mancode init` 提示"not a project directory"
 
-交互式终端中的空目录会询问是否初始化为通用项目，不需要 Git 或 npm 命令。为了保护已有
-文件，未识别且非空的目录仍会被拒绝；请进入真正的项目目录。脚本里只应针对明确为空的
-目录使用 `mancode init --empty --platform <platform>`。
+Git 不是初始化前提。mancode 会把常见 manifest、顶层源码文件（如 `.html`、`.js`、
+`.py`、`.go`）或源码目录（如 `src/`、`app/`、`web/`）视为项目证据。检测只看当前目录
+顶层，不会因为子目录里有代码而把素材包父目录误认为项目；此时请进入实际源码目录。
+
+交互式终端中的空目录会询问是否初始化为通用项目。为了保护已有文件，只有素材、文档等
+内容且没有项目证据的非空目录仍会被拒绝。脚本里只应针对明确为空的目录使用
+`mancode init --empty --platform <platform>`。Home 与磁盘根目录始终不能初始化。
 
 ### Claude Code hooks 不生效
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mancode",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mancode",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "commander": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mancode",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AI coding agent workflow harness with mancode Continuity for cross-conversation tasks, decisions, verification, and team coordination.",
   "type": "module",
   "license": "AGPL-3.0-only",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -30,8 +30,8 @@ import {
   parsePlatformSelection,
 } from '../system/init-onboarding.js';
 import {
-  PROJECT_MANIFESTS,
   detectProjectProfile,
+  hasProjectEvidence,
   primaryUiLibrary,
 } from '../system/project-profile.js';
 import { scanAesthetics } from '../system/scan-aesthetics.js';
@@ -229,13 +229,17 @@ export async function init(
     return initializeV3(rootDir, options);
   }
 
-  // 2.1 校验是项目目录（git 或任一常见项目 manifest）。空目录可明确作为通用项目初始化。
+  // 2.1 校验是项目目录（git、manifest 或源码证据）。空目录可明确作为通用项目初始化。
+  const genericSafety = await canInitializeGenericProject(rootDir);
+  if (!genericSafety.ok && genericSafety.reason === 'unsafe') {
+    printNotProjectDirectory(rootDir, locale, 'unsafe');
+    return EXIT_NOT_A_PROJECT_DIR;
+  }
   const isGitRepo = await pathExists(path.join(rootDir, '.git'));
-  const hasManifest = await hasProjectManifest(rootDir);
+  const hasEvidence = await hasProjectEvidence(rootDir);
   let isGenericProject = false;
 
-  if (!isGitRepo && !hasManifest) {
-    const genericSafety = await canInitializeGenericProject(rootDir);
+  if (!isGitRepo && !hasEvidence) {
     if (
       !genericSafety.ok &&
       !(wasInitialized && genericSafety.reason === 'nonempty')
@@ -305,12 +309,12 @@ export async function init(
       if (uiLibrary) {
         console.log(`   UI: ${uiLibraryStr}`);
       }
-    } else if (hasManifest) {
+    } else if (hasEvidence) {
       console.log(
         localize(
           locale,
-          '   已发现项目 manifest，未识别到框架依赖',
-          '   Project manifest found; no known framework dependencies',
+          '   已发现项目源码，未识别到框架依赖',
+          '   Project source found; no known framework dependencies',
         ),
       );
     } else {
@@ -975,13 +979,6 @@ async function selectInitPlatforms(input: {
   return [DEFAULT_INIT_PLATFORM];
 }
 
-async function hasProjectManifest(rootDir: string): Promise<boolean> {
-  for (const name of PROJECT_MANIFESTS) {
-    if (await pathExists(path.join(rootDir, name))) return true;
-  }
-  return false;
-}
-
 async function canInitializeGenericProject(
   rootDir: string,
 ): Promise<{ ok: true } | { ok: false; reason: 'unsafe' | 'nonempty' }> {
@@ -1012,16 +1009,20 @@ async function validateV3CliProjectBoundary(
   locale: InitLocale,
   legacyInitialized: boolean,
 ): Promise<number | null> {
+  const genericSafety = await canInitializeGenericProject(rootDir);
+  if (!genericSafety.ok && genericSafety.reason === 'unsafe') {
+    printNotProjectDirectory(rootDir, locale, 'unsafe');
+    return EXIT_NOT_A_PROJECT_DIR;
+  }
   const isGitRepo = await pathExists(path.join(rootDir, '.git'));
-  const hasManifest = await hasProjectManifest(rootDir);
-  if (isGitRepo || hasManifest) return null;
+  const hasEvidence = await hasProjectEvidence(rootDir);
+  if (isGitRepo || hasEvidence) return null;
 
   const v3Initialized = await pathExists(
     path.join(rootDir, '.mancode', 'schema.json'),
   );
   const legacyAuthorityPresent =
     legacyInitialized || (await scanLegacyAuthority(rootDir)).authorityPresent;
-  const genericSafety = await canInitializeGenericProject(rootDir);
   if (
     !genericSafety.ok &&
     !(
@@ -1060,7 +1061,7 @@ function printNotProjectDirectory(
       console.error('   为避免误写，不能在 Home 目录或磁盘根目录初始化。');
     } else if (reason === 'nonempty') {
       console.error(
-        '   未识别到项目文件，且目录中已有文件。请先进入项目目录。',
+        '   未识别到顶层项目清单、源码文件或源码目录。请先进入实际项目根目录。',
       );
     } else {
       console.error(
@@ -1076,7 +1077,7 @@ function printNotProjectDirectory(
     );
   } else if (reason === 'nonempty') {
     console.error(
-      '   No project files were detected and the directory is not empty.',
+      '   No top-level manifest, source file, or source directory was detected.',
     );
   } else {
     console.error(

--- a/src/commands/refresh-project.ts
+++ b/src/commands/refresh-project.ts
@@ -13,8 +13,8 @@ import {
 } from '../installers/registry.js';
 import { detectTeamStatus } from '../system/detect-team.js';
 import {
-  PROJECT_MANIFESTS,
   detectProjectProfile,
+  hasProjectEvidence,
   primaryUiLibrary,
 } from '../system/project-profile.js';
 
@@ -23,7 +23,7 @@ export const EXIT_NOT_INITIALIZED = 1;
 export const EXIT_CORRUPT_STATE = 2;
 export const EXIT_REFRESH_FAILED = 3;
 
-/** Refresh facts that can change after a generic project later gains Git or a manifest. */
+/** Refresh facts that can change after a generic project later gains Git or source evidence. */
 export async function refreshProject(
   rootDir: string = process.cwd(),
 ): Promise<number> {
@@ -47,11 +47,11 @@ export async function refreshProject(
 
   let factsWritten = false;
   try {
-    const [profile, team, hasGit, hasManifest] = await Promise.all([
+    const [profile, team, hasGit, hasEvidence] = await Promise.all([
       detectProjectProfile(rootDir),
       detectTeamStatus(rootDir),
       pathExists(path.join(rootDir, '.git')),
-      hasProjectManifest(rootDir),
+      hasProjectEvidence(rootDir),
     ]);
     const uiLibrary = primaryUiLibrary(profile);
     const stack = [...profile.languages, ...profile.frameworks];
@@ -68,7 +68,7 @@ export async function refreshProject(
       ...state,
       techStack: stack.join(' + ') || profile.projectKind,
       uiLibrary: uiLibrary ?? 'None',
-      projectMode: hasGit || hasManifest ? 'detected' : 'generic',
+      projectMode: hasGit || hasEvidence ? 'detected' : 'generic',
       teamModeAutoDetected: configuredTeam,
       contributors: team.contributors,
     };
@@ -90,7 +90,7 @@ export async function refreshProject(
     );
     console.log('✓  Project facts refreshed.');
     console.log(
-      `   ${hasGit ? 'Git detected' : 'No Git repository'} | ${hasManifest ? 'project manifest detected' : 'generic project'}`,
+      `   ${hasGit ? 'Git detected' : 'No Git repository'} | ${hasEvidence ? 'project source detected' : 'generic project'}`,
     );
     console.log(
       `   Stack: ${nextState.techStack} | UI: ${nextState.uiLibrary}`,
@@ -138,13 +138,6 @@ async function refreshV3Project(rootDir: string): Promise<number> {
     console.error(`✗  mancode project facts refresh failed: ${message}`);
     return EXIT_REFRESH_FAILED;
   }
-}
-
-async function hasProjectManifest(rootDir: string): Promise<boolean> {
-  for (const manifest of PROJECT_MANIFESTS) {
-    if (await pathExists(path.join(rootDir, manifest))) return true;
-  }
-  return false;
 }
 
 async function writeProjectFacts(

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -36,7 +36,7 @@ import {
   detectTeamAssessmentSignals,
   detectTeamStatus,
 } from '../system/detect-team.js';
-import { PROJECT_MANIFESTS } from '../system/project-profile.js';
+import { hasProjectEvidence } from '../system/project-profile.js';
 import {
   type WorkflowMode,
   type WorkflowOutcome,
@@ -556,10 +556,7 @@ async function shouldRefreshProject(
   if (state.projectMode !== 'generic') return false;
   const hasGit = await pathExists(path.join(rootDir, '.git'));
   if (hasGit) return true;
-  for (const manifest of PROJECT_MANIFESTS) {
-    if (await pathExists(path.join(rootDir, manifest))) return true;
-  }
-  return false;
+  return hasProjectEvidence(rootDir);
 }
 
 async function checkPlatformStatus(

--- a/src/system/project-profile.ts
+++ b/src/system/project-profile.ts
@@ -38,25 +38,77 @@ export const PROJECT_MANIFESTS = [
   'pubspec.yaml',
 ] as const;
 
+const PROJECT_SOURCE_EXTENSIONS = new Set([
+  '.c',
+  '.cc',
+  '.cpp',
+  '.cs',
+  '.css',
+  '.dart',
+  '.go',
+  '.html',
+  '.java',
+  '.js',
+  '.jsx',
+  '.kt',
+  '.kts',
+  '.m',
+  '.mm',
+  '.php',
+  '.py',
+  '.rb',
+  '.rs',
+  '.scala',
+  '.sh',
+  '.swift',
+  '.ts',
+  '.tsx',
+  '.vue',
+]);
+
+const PROJECT_SOURCE_ROOTS = [
+  'src',
+  'app',
+  'apps',
+  'packages',
+  'web',
+  'lib',
+  'Sources',
+  'cmd',
+  'server',
+  'backend',
+  'mobile',
+  'ios',
+  'android',
+] as const;
+
+const PROJECT_MANIFEST_NAMES = new Set<string>(PROJECT_MANIFESTS);
+const PROJECT_SOURCE_ROOT_NAMES = new Set<string>(PROJECT_SOURCE_ROOTS);
+
+/** Detect explicit, top-level evidence that the directory itself is a project. */
+export async function hasProjectEvidence(
+  projectRoot: string,
+): Promise<boolean> {
+  const entries = await readdir(projectRoot, { withFileTypes: true }).catch(
+    () => [],
+  );
+  return entries.some((entry) => {
+    if (entry.isDirectory()) return PROJECT_SOURCE_ROOT_NAMES.has(entry.name);
+    if (!entry.isFile()) return false;
+    return (
+      PROJECT_MANIFEST_NAMES.has(entry.name) ||
+      PROJECT_SOURCE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())
+    );
+  });
+}
+
 export async function detectProjectProfile(
   projectRoot: string,
 ): Promise<ProjectProfile> {
   const entries = await readdir(projectRoot).catch(() => [] as string[]);
   const manifests = PROJECT_MANIFESTS.filter((file) => entries.includes(file));
   const sourceRoots = await existingDirs(projectRoot, [
-    'src',
-    'app',
-    'apps',
-    'packages',
-    'web',
-    'lib',
-    'Sources',
-    'cmd',
-    'server',
-    'backend',
-    'mobile',
-    'ios',
-    'android',
+    ...PROJECT_SOURCE_ROOTS,
     'data',
     'notebooks',
   ]);

--- a/tests/init-onboarding.test.ts
+++ b/tests/init-onboarding.test.ts
@@ -216,6 +216,22 @@ describe('init onboarding', () => {
     expect(config.platforms).toEqual(['codex', 'cursor']);
   });
 
+  it('initializes an existing source project without Git or a manifest', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-source-project-'));
+    dirs.push(dir);
+    await Promise.all([
+      writeFile(path.join(dir, 'index.html'), '<canvas id="game"></canvas>\n'),
+      writeFile(path.join(dir, 'game.js'), 'console.log("game");\n'),
+      writeFile(path.join(dir, 'style.css'), 'body { margin: 0; }\n'),
+    ]);
+
+    expect(await init(dir, { platform: 'codex' })).toBe(EXIT_OK);
+    const state = JSON.parse(
+      await readFile(path.join(dir, '.mancode', 'state.json'), 'utf-8'),
+    );
+    expect(state.projectMode).toBe('detected');
+  });
+
   it('force reinstalls an initialized generic project without project markers', async () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'mancode-generic-force-'));
     dirs.push(dir);
@@ -238,6 +254,7 @@ describe('init onboarding', () => {
     await mkdir(path.join(dir, '.mancode'));
     await writeFile(path.join(dir, '.mancode', 'state.json'), '{}\n');
     await writeFile(path.join(dir, 'notes.txt'), 'user content\n');
+    await writeFile(path.join(dir, 'game.js'), 'console.log("game");\n');
     const homedir = vi.spyOn(os, 'homedir').mockReturnValue(dir);
 
     try {
@@ -249,6 +266,9 @@ describe('init onboarding', () => {
     }
     await expect(readFile(path.join(dir, 'notes.txt'), 'utf-8')).resolves.toBe(
       'user content\n',
+    );
+    await expect(readFile(path.join(dir, 'game.js'), 'utf-8')).resolves.toBe(
+      'console.log("game");\n',
     );
   });
 
@@ -312,6 +332,19 @@ describe('init onboarding', () => {
       path.join(dir, 'package.json'),
       '{"name":"later-project"}\n',
     );
+    expect(await refreshProject(dir)).toBe(EXIT_OK);
+    const state = JSON.parse(
+      await readFile(path.join(dir, '.mancode', 'state.json'), 'utf-8'),
+    );
+    expect(state.projectMode).toBe('detected');
+  });
+
+  it('refreshes a generic project after a source file is added', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-refresh-source-'));
+    dirs.push(dir);
+    expect(await init(dir, { empty: true, platform: 'codex' })).toBe(EXIT_OK);
+    await writeFile(path.join(dir, 'game.js'), 'console.log("game");\n');
+
     expect(await refreshProject(dir)).toBe(EXIT_OK);
     const state = JSON.parse(
       await readFile(path.join(dir, '.mancode', 'state.json'), 'utf-8'),

--- a/tests/project-profile.test.ts
+++ b/tests/project-profile.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   detectProjectProfile,
+  hasProjectEvidence,
   primaryUiLibrary,
 } from '../src/system/project-profile.js';
 
@@ -22,6 +23,31 @@ describe('project profile', () => {
     expect(profile.projectKind).toBe('unknown');
     expect(profile.uiAssets).toBe('none');
     expect(profile.browserAutomation).toBe('unavailable');
+  });
+
+  it('recognizes top-level source files as project evidence', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-profile-'));
+    dirs.push(dir);
+    await Promise.all([
+      writeFile(path.join(dir, 'index.html'), '<canvas id="game"></canvas>\n'),
+      writeFile(path.join(dir, 'game.js'), 'console.log("game");\n'),
+      writeFile(path.join(dir, 'style.css'), 'body { margin: 0; }\n'),
+    ]);
+
+    await expect(hasProjectEvidence(dir)).resolves.toBe(true);
+  });
+
+  it('does not infer project evidence from assets or nested source files', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'mancode-profile-'));
+    dirs.push(dir);
+    await mkdir(path.join(dir, 'game'));
+    await Promise.all([
+      writeFile(path.join(dir, 'Preview.png'), 'asset\n'),
+      writeFile(path.join(dir, 'License.txt'), 'license\n'),
+      writeFile(path.join(dir, 'game', 'game.js'), 'console.log("game");\n'),
+    ]);
+
+    await expect(hasProjectEvidence(dir)).resolves.toBe(false);
   });
 
   it('recognizes a Go backend without package.json', async () => {

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -103,6 +103,16 @@ describe('mancode status', () => {
     expect(result.project).toBe(path.basename(dir));
   });
 
+  it('recommends refreshing a generic project after source is added', async () => {
+    await rm(path.join(dir, '.git'), { recursive: true, force: true });
+    await silentInit(dir, { empty: true, platform: 'codex' });
+    await writeFile(path.join(dir, 'game.js'), 'console.log("game");\n');
+
+    const logs = await captureLog(() => status(dir, { json: true }));
+    const result: StatusResult = JSON.parse(logs.join('\n'));
+    expect(result.projectRefreshRecommended).toBe(true);
+  });
+
   it('detects missing hook files', async () => {
     await silentInit(dir);
 

--- a/tests/v3-init-command.test.ts
+++ b/tests/v3-init-command.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import os, { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
   afterAll,
@@ -230,6 +230,37 @@ describe('journaled V3 init command', () => {
         platform: 'codex',
       }),
     ).toBe(EXIT_NOT_A_PROJECT_DIR);
+    await expect(
+      readFile(path.join(root, '.mancode', 'schema.json'), 'utf8'),
+    ).rejects.toThrow();
+  });
+
+  it('initializes a static web project without Git or a package manifest', async () => {
+    await Promise.all([
+      writeFile(path.join(root, 'index.html'), '<canvas id="game"></canvas>\n'),
+      writeFile(path.join(root, 'game.js'), 'console.log("game");\n'),
+      writeFile(path.join(root, 'style.css'), 'body { margin: 0; }\n'),
+    ]);
+
+    expect(await init(root, { fromCli: true, platform: 'codex' })).toBe(
+      EXIT_OK,
+    );
+    await expect(
+      readFile(path.join(root, '.mancode', 'schema.json'), 'utf8'),
+    ).resolves.toContain('"activationState": "v3_active"');
+  });
+
+  it('still refuses a home directory even when it contains source files', async () => {
+    await writeFile(path.join(root, 'game.js'), 'console.log("game");\n');
+    const homedir = vi.spyOn(os, 'homedir').mockReturnValue(root);
+
+    try {
+      expect(await init(root, { fromCli: true, platform: 'codex' })).toBe(
+        EXIT_NOT_A_PROJECT_DIR,
+      );
+    } finally {
+      homedir.mockRestore();
+    }
     await expect(
       readFile(path.join(root, '.mancode', 'schema.json'), 'utf8'),
     ).rejects.toThrow();

--- a/website/docs.html
+++ b/website/docs.html
@@ -24,7 +24,7 @@
 
     <header class="docs-topbar">
       <a class="brand" href="./index.html" aria-label="mancode home"><img src="./logo.png" alt="" /><span>mancode</span><i aria-hidden="true"></i></a>
-      <span class="docs-wordmark">Documentation / v0.6.0</span>
+      <span class="docs-wordmark">Documentation / v0.6.1</span>
       <div class="docs-top-links">
         <a href="./index.html">Website</a>
         <a href="https://github.com/whitelonng/mancode">GitHub</a>
@@ -62,7 +62,7 @@
 
         <section class="doc-section" id="install" data-searchable>
           <h2>Install &amp; initialize</h2>
-          <p>Node.js 22 or newer is required. Run the initializer inside an existing project or a safe empty directory, then choose one or more agent adapters. Windows CMD, PowerShell, and Git Bash are supported; Git is optional and only improves team-mode detection.</p>
+          <p>Node.js 22 or newer is required. Run the initializer inside an existing project or a safe empty directory, then choose one or more agent adapters. Windows CMD, PowerShell, and Git Bash are supported; Git is optional and only improves team-mode detection. A manifest, top-level source file, or common source root in the current directory also counts as project evidence.</p>
           <div class="docs-steps">
             <article class="docs-step"><b>01</b><strong>Install</strong><p>Install the CLI once on your machine.</p></article>
             <article class="docs-step"><b>02</b><strong>Enter</strong><p>Open the project the agent should understand.</p></article>
@@ -81,7 +81,7 @@
             <tr><td><code>--force</code></td><td>Repair generated configuration</td><td>Reinstalls managed content while preserving detected style tokens and content outside managed blocks.</td></tr>
             <tr><td><code>--yes</code></td><td>CI or a non-interactive shell</td><td>Accepts safe defaults and skips generic-project confirmation; pair it with <code>--platform</code>.</td></tr>
             <tr><td><code>--platform LIST</code></td><td>You know the target agents</td><td>Installs one or more of <code>claude-code</code>, <code>cursor</code>, <code>codex</code>, <code>copilot</code>, <code>zcode</code>, <code>kimi-code</code>, and <code>qoder</code>.</td></tr>
-            <tr><td><code>--empty</code></td><td>The directory is intentionally empty</td><td>Allows generic-project initialization without <code>git init</code> or a package manifest.</td></tr>
+            <tr><td><code>--empty</code></td><td>The directory is intentionally empty</td><td>Allows generic-project initialization without <code>git init</code>, a package manifest, or source evidence.</td></tr>
             <tr><td><code>--team</code> / <code>--no-team</code></td><td>Auto-detection is not the policy you want</td><td>Forces shared-memory mode on or off.</td></tr>
             <tr><td><code>--style NAME</code></td><td>You explicitly initialize with <code>--legacy</code></td><td>Stores the old free-text style preference. Continuity projects use the revisioned <code>mancode design</code> policy instead.</td></tr>
             <tr><td><code>--lang en|zh-CN</code></td><td>You need deterministic generated text</td><td>Sets the generated-content locale.</td></tr>
@@ -215,7 +215,7 @@ $manteam</code></pre><button type="button" data-copy-code>Copy</button></div></a
             <article class="command-card"><header><h3>mancode workflow &lt;subcommand&gt;</h3><span>Govern</span></header><p>Creates and validates Continuity requirements, plans, verification evidence, reviews, remediation, and completion.</p><ul><li>Inspect with <code>list</code> and <code>show &lt;namespace:ULID&gt; [--json]</code>.</li><li>Use <code>context compact --dry-run</code> to inspect removable runtime records; Continuity workflow authority is not deleted by <code>workflow clean</code>.</li></ul></article>
             <article class="command-card"><header><h3>mancode manps [area]</h3><span>Scan</span></header><p>Runs a deterministic health scan for <code>all</code>, <code>deps</code>, <code>security</code>, <code>dead-code</code>, <code>config</code>.</p><ul><li><code>--json</code> emits machine-readable output.</li><li><code>--remediate</code> enters the explicit remediation path; the default is scan-only.</li></ul></article>
             <article class="command-card"><header><h3>mancode design status | context | configure | disable</h3><span>Design</span></header><p>Inspects effective UI guidance or changes the revisioned project design policy. Configuration requires <code>--expected-revision &lt;n&gt;</code>; experimental mode also requires <code>--confirm-experimental</code>.</p></article>
-            <article class="command-card"><header><h3>mancode refresh-project</h3><span>Rescan</span></header><p>Refreshes project facts after adding Git, a manifest, a framework, or validation commands, then reports stale adapters.</p></article>
+            <article class="command-card"><header><h3>mancode refresh-project</h3><span>Rescan</span></header><p>Refreshes project facts after adding Git, a manifest, source, a framework, or validation commands, then reports stale adapters.</p></article>
             <article class="command-card"><header><h3>mancode refresh-style</h3><span>Design</span></header><p>Refreshes the project profile and design tokens. Preview any adapter repair with <code>mancode adapter upgrade --platform &lt;platform&gt; --dry-run</code>.</p></article>
             <article class="command-card"><header><h3>mancode uninstall [platform]</h3><span>Remove</span></header><p>Removes one Continuity adapter. Continuity protects authority from bulk removal; use <code>context compact --dry-run</code> for retention candidates. The <code>--all</code> form is legacy-only.</p></article>
             <article class="command-card"><header><h3>mancode version</h3><span>Version</span></header><p>Prints the installed CLI version for upgrade checks and issue reports.</p></article>
@@ -482,7 +482,7 @@ $manteam</code></pre><button type="button" data-copy-code>Copy</button></div></a
         <section class="doc-section" id="troubleshooting" data-searchable>
           <h2>Troubleshooting</h2>
           <h3><code>mancode init</code> rejects the directory</h3>
-          <p>A safely empty directory is supported interactively, or explicitly with <code>--empty</code>. A non-empty directory still needs a recognized project marker or Git metadata so mancode does not initialize an arbitrary folder by accident.</p>
+          <p>Git is not required. A common manifest, top-level source file such as <code>.html</code>, <code>.js</code>, <code>.py</code>, or <code>.go</code>, or source root such as <code>src/</code>, <code>app/</code>, or <code>web/</code> counts as project evidence. Detection inspects only the current directory's top level, so enter the actual source directory rather than an asset-pack parent. Safe empty directories are supported interactively or explicitly with <code>--empty</code>; non-empty directories containing only assets or documentation are still rejected. Home and filesystem root directories remain protected.</p>
           <h3>The agent does not see a newly installed mode</h3>
           <p>Reload or restart the agent so it rereads repository instructions. Run <code>mancode status</code>; if the adapter is not ready, preview <code>mancode adapter upgrade --platform &lt;platform&gt; --dry-run</code>, then repair it from an active session with <code>--confirm --operation-id &lt;operationId&gt;</code>. For ZCode, Copilot, Kimi Code, Qoder, and DeepSeek Harness, also confirm that the installed client release supports repository skills, prompt files, or project commands.</p>
           <h3>Claude Code hooks do not run</h3>
@@ -492,7 +492,7 @@ $manteam</code></pre><button type="button" data-copy-code>Copy</button></div></a
           <h3>A workflow command is rejected</h3>
           <p>Treat the rejection as a gate, not a file-corruption problem. Use <code>mancode workflow list --json</code> to discover TaskRefs, then <code>mancode workflow show &lt;namespace:ULID&gt; --json</code> to inspect metadata, revision, aggregate, and blockers. Do not edit Continuity metadata manually.</p>
           <h3>Project facts became stale</h3>
-          <p>After adding Git, a manifest, dependencies, or validation scripts, run <code>mancode refresh-project</code>. Use <code>refresh-style</code> for UI tokens. Then repair a static adapter only if its generated files need regeneration.</p>
+          <p>After adding Git, a manifest, source, dependencies, or validation scripts, run <code>mancode refresh-project</code>. Use <code>refresh-style</code> for UI tokens. Then repair a static adapter only if its generated files need regeneration.</p>
         </section>
 
         <p class="docs-search-empty" data-search-empty>No documentation sections match your search.</p>

--- a/website/docs.zh-CN.html
+++ b/website/docs.zh-CN.html
@@ -24,7 +24,7 @@
 
     <header class="docs-topbar">
       <a class="brand" href="./index.zh-CN.html" aria-label="mancode 首页"><img src="./logo.png" alt="" /><span>mancode</span><i aria-hidden="true"></i></a>
-      <span class="docs-wordmark">文档 / v0.6.0</span>
+      <span class="docs-wordmark">文档 / v0.6.1</span>
       <div class="docs-top-links">
         <a href="./index.zh-CN.html">官网</a>
         <a href="https://github.com/whitelonng/mancode">GitHub</a>
@@ -62,7 +62,7 @@
 
         <section class="doc-section" id="install" data-searchable>
           <h2>安装与初始化</h2>
-          <p>需要 Node.js 22 或更高版本。你可以在现有项目或安全的空目录中初始化，然后选择一个或多个 Agent 适配器。Windows CMD、PowerShell 和 Git Bash 均受支持；Git 不是必需依赖，只会帮助 mancode 更准确地判断团队模式。</p>
+          <p>需要 Node.js 22 或更高版本。你可以在现有项目或安全的空目录中初始化，然后选择一个或多个 Agent 适配器。Windows CMD、PowerShell 和 Git Bash 均受支持；Git 不是必需依赖，只会帮助 mancode 更准确地判断团队模式。当前目录存在 manifest、顶层源码文件或常见源码目录时，同样会被识别为项目。</p>
           <div class="docs-steps">
             <article class="docs-step"><b>01</b><strong>安装</strong><p>在本机全局安装一次 CLI。</p></article>
             <article class="docs-step"><b>02</b><strong>进入项目</strong><p>进入希望 Agent 理解的项目目录。</p></article>
@@ -81,7 +81,7 @@
             <tr><td><code>--force</code></td><td>修复生成配置</td><td>重新安装 mancode 管理的内容，同时保留已扫描的样式 token 和受控标记之外的用户内容。</td></tr>
             <tr><td><code>--yes</code></td><td>CI 或非交互终端</td><td>接受安全默认值并跳过通用项目确认；建议同时给出 <code>--platform</code>。</td></tr>
             <tr><td><code>--platform LIST</code></td><td>已经知道目标 Agent</td><td>安装 <code>claude-code</code>、<code>cursor</code>、<code>codex</code>、<code>copilot</code>、<code>zcode</code>、<code>kimi-code</code>、<code>qoder</code> 中的一个或多个。</td></tr>
-            <tr><td><code>--empty</code></td><td>目录有意保持为空</td><td>无需先执行 <code>git init</code> 或创建 manifest，也能初始化通用项目。</td></tr>
+            <tr><td><code>--empty</code></td><td>目录有意保持为空</td><td>无需先执行 <code>git init</code>、创建 manifest 或源码证据，也能初始化通用项目。</td></tr>
             <tr><td><code>--team</code> / <code>--no-team</code></td><td>不采用自动判断结果</td><td>强制开启或关闭团队共享上下文。</td></tr>
             <tr><td><code>--style NAME</code></td><td>显式使用 <code>--legacy</code> 初始化</td><td>保存旧版自由文本样式偏好。Continuity 项目改用带 revision 的 <code>mancode design</code> 策略。</td></tr>
             <tr><td><code>--lang en|zh-CN</code></td><td>需要稳定的生成语言</td><td>指定生成内容的语言。</td></tr>
@@ -215,7 +215,7 @@ $manteam</code></pre><button type="button" data-copy-code>复制</button></div><
             <article class="command-card"><header><h3>mancode workflow &lt;subcommand&gt;</h3><span>治理</span></header><p>创建和校验 Continuity 需求、计划、验证证据、评审、修复与完成状态。</p><ul><li>使用 <code>list</code> 和 <code>show &lt;namespace:ULID&gt; [--json]</code> 检查。</li><li>使用 <code>context compact --dry-run</code> 检查可回收的运行时记录；Continuity workflow authority 不会被 <code>workflow clean</code> 删除。</li></ul></article>
             <article class="command-card"><header><h3>mancode manps [area]</h3><span>扫描</span></header><p>对 <code>all</code>、<code>deps</code>、<code>security</code>、<code>dead-code</code> 或 <code>config</code> 执行确定性健康扫描。</p><ul><li><code>--json</code> 输出机器可读结果。</li><li><code>--remediate</code> 显式进入修复路径；默认只扫描。</li></ul></article>
             <article class="command-card"><header><h3>mancode design status | context | configure | disable</h3><span>设计</span></header><p>检查有效 UI 指导，或修改带 revision 的项目设计策略。配置必须传入 <code>--expected-revision &lt;n&gt;</code>；experimental 还需要 <code>--confirm-experimental</code>。</p></article>
-            <article class="command-card"><header><h3>mancode refresh-project</h3><span>重扫项目</span></header><p>在加入 Git、manifest、框架或验证命令后刷新项目事实，并报告 stale adapter。</p></article>
+            <article class="command-card"><header><h3>mancode refresh-project</h3><span>重扫项目</span></header><p>在加入 Git、manifest、源码、框架或验证命令后刷新项目事实，并报告 stale adapter。</p></article>
             <article class="command-card"><header><h3>mancode refresh-style</h3><span>设计上下文</span></header><p>刷新项目画像和设计 token；adapter 修复先用 <code>mancode adapter upgrade --platform &lt;platform&gt; --dry-run</code> 预览。</p></article>
             <article class="command-card"><header><h3>mancode uninstall [platform]</h3><span>移除</span></header><p>移除一个 Continuity 适配器。Continuity 会保护权威数据不被批量删除；用 <code>context compact --dry-run</code> 检查保留候选。<code>--all</code> 只适用于 legacy 项目。</p></article>
             <article class="command-card"><header><h3>mancode version</h3><span>版本</span></header><p>输出已安装 CLI 版本，便于升级检查和提交问题。</p></article>
@@ -482,7 +482,7 @@ $manteam</code></pre><button type="button" data-copy-code>复制</button></div><
         <section class="doc-section" id="troubleshooting" data-searchable>
           <h2>故障排查</h2>
           <h3><code>mancode init</code> 拒绝当前目录</h3>
-          <p>安全的空目录支持交互初始化，也可以显式使用 <code>--empty</code>。非空目录仍需存在可识别的项目标记或 Git 元数据，防止 mancode 意外初始化任意文件夹。</p>
+          <p>Git 不是必需条件。常见 manifest、顶层源码文件（如 <code>.html</code>、<code>.js</code>、<code>.py</code>、<code>.go</code>）或源码目录（如 <code>src/</code>、<code>app/</code>、<code>web/</code>）都会被视为项目证据。检测只查看当前目录顶层，因此素材包父目录不会因为深层子项目而被误判；请进入实际源码目录。安全的空目录支持交互初始化或显式使用 <code>--empty</code>，但只有素材、文档且没有项目证据的非空目录仍会被拒绝。Home 与磁盘根目录继续受保护。</p>
           <h3>Agent 看不到刚安装的模式</h3>
           <p>重载或重启 Agent，让它重新读取仓库 instructions。执行 <code>mancode status</code>；如果平台未 ready，先运行 <code>mancode adapter upgrade --platform &lt;platform&gt; --dry-run</code>，再从 active session 用 <code>--confirm --operation-id &lt;operationId&gt;</code> 修复。ZCode、Copilot、Kimi Code、Qoder 和 DeepSeek Harness 还需要确认当前客户端版本支持仓库 skills、prompt files 或项目 commands。</p>
           <h3>Claude Code hooks 没有触发</h3>
@@ -492,7 +492,7 @@ $manteam</code></pre><button type="button" data-copy-code>复制</button></div><
           <h3>workflow 命令被拒绝</h3>
           <p>把拒绝当作流程闸门，而不是元数据损坏。先用 <code>mancode workflow list --json</code> 找到 TaskRef，再用 <code>mancode workflow show &lt;namespace:ULID&gt; --json</code> 检查元数据、revision、aggregate 和 blocker。不要手工编辑 Continuity metadata。</p>
           <h3>项目事实已经过期</h3>
-          <p>添加 Git、manifest、依赖或验证脚本后执行 <code>mancode refresh-project</code>；UI token 改变时执行 <code>refresh-style</code>。只有静态适配器的生成文件需要更新时，才重新安装对应平台。</p>
+          <p>添加 Git、manifest、源码、依赖或验证脚本后执行 <code>mancode refresh-project</code>；UI token 改变时执行 <code>refresh-style</code>。只有静态适配器的生成文件需要更新时，才重新安装对应平台。</p>
         </section>
 
         <p class="docs-search-empty" data-search-empty>没有找到匹配的文档章节。</p>

--- a/website/index.html
+++ b/website/index.html
@@ -512,7 +512,7 @@
         <a href="https://github.com/whitelonng/mancode/blob/main/README.md">中文</a>
         <a href="https://github.com/whitelonng/mancode/blob/main/LICENSE">AGPL-3.0</a>
       </div>
-      <span class="footer-status"><i></i> Continuity / v0.6.0</span>
+      <span class="footer-status"><i></i> Continuity / v0.6.1</span>
     </footer>
   </body>
 </html>

--- a/website/index.zh-CN.html
+++ b/website/index.zh-CN.html
@@ -121,6 +121,6 @@
 
       <section class="final-cta"><div class="final-cta-mark" aria-hidden="true">M</div><p class="reveal">简单任务少一点仪式。<br />关键任务多一点纪律。</p><h2 class="reveal">别再替 AI<br />收拾臃肿。</h2><div class="final-actions reveal"><div class="command-bar command-light"><code><span>&gt;</span> npm install -g mancode</code><button type="button" data-copy="npm install -g mancode">复制</button></div><a class="button button-dark" href="https://github.com/whitelonng/mancode">GitHub 上查看 ↗</a></div></section>
     </main>
-    <footer class="site-footer"><a class="brand footer-brand" href="#top"><img src="./logo.png" alt="" /><span>mancode</span></a><p>AI 编码 Agent 工作流调度工具。<br />日常训练，关键任务季后赛。</p><div class="footer-links"><a href="https://github.com/whitelonng/mancode">GitHub</a><a href="./docs.zh-CN.html">中文文档</a><a href="./docs.html">English</a><a href="https://github.com/whitelonng/mancode/blob/main/LICENSE">AGPL-3.0</a></div><span class="footer-status"><i></i> Continuity / v0.6.0</span></footer>
+    <footer class="site-footer"><a class="brand footer-brand" href="#top"><img src="./logo.png" alt="" /><span>mancode</span></a><p>AI 编码 Agent 工作流调度工具。<br />日常训练，关键任务季后赛。</p><div class="footer-links"><a href="https://github.com/whitelonng/mancode">GitHub</a><a href="./docs.zh-CN.html">中文文档</a><a href="./docs.html">English</a><a href="https://github.com/whitelonng/mancode/blob/main/LICENSE">AGPL-3.0</a></div><span class="footer-status"><i></i> Continuity / v0.6.1</span></footer>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- recognize non-Git projects from top-level manifests, source files, or source roots
- keep nested asset-pack parents and unsafe roots protected
- share project evidence across init, status, and refresh-project
- publish public docs and package metadata as 0.6.1

## Verification

- npm run prepublishOnly
- 127 test files and 933 tests passed