### PR TITLE
release: mancode 0.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mancode",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mancode",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "commander": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mancode",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "AI coding agent workflow harness with mancode Continuity for cross-conversation tasks, decisions, verification, and team coordination.",
   "type": "module",
   "license": "AGPL-3.0-only",

--- a/src/installers/v3-adapter.ts
+++ b/src/installers/v3-adapter.ts
@@ -3,6 +3,7 @@ import {
   lstat,
   mkdir,
   readFile,
+  realpath,
   rename,
   rm,
   rmdir,
@@ -2376,11 +2377,15 @@ async function assertAdapterPathSafe(
 ): Promise<void> {
   const relative = path.relative(root, target);
   if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
-    throw new Error('MANCODE_ARTIFACT_PATH_UNSAFE');
+    throw new Error(
+      `MANCODE_ARTIFACT_PATH_UNSAFE: adapter target must stay inside the project root: ${target}`,
+    );
   }
   const rootEntry = await lstat(root);
   if (!rootEntry.isDirectory() || rootEntry.isSymbolicLink()) {
-    throw new Error('MANCODE_ARTIFACT_PATH_UNSAFE');
+    throw new Error(
+      `MANCODE_ARTIFACT_PATH_UNSAFE: project root must be a real directory, not a symbolic link: ${root}`,
+    );
   }
   const segments = relative.split(path.sep);
   let current = root;
@@ -2388,16 +2393,32 @@ async function assertAdapterPathSafe(
     current = path.join(current, segments[index] ?? '');
     try {
       const entry = await lstat(current);
-      if (
-        entry.isSymbolicLink() ||
-        (index < segments.length - 1 && !entry.isDirectory())
-      ) {
-        throw new Error('MANCODE_ARTIFACT_PATH_UNSAFE');
+      if (entry.isSymbolicLink()) {
+        const detail = await describeAdapterSymlink(current);
+        const replacement =
+          index === segments.length - 1 ? 'a regular file' : 'a real directory';
+        throw new Error(
+          `MANCODE_ARTIFACT_PATH_UNSAFE: ${relative} is a symbolic link${detail}; mancode never writes through links. Replace it with ${replacement} before initializing the adapter.`,
+        );
+      }
+      if (index < segments.length - 1 && !entry.isDirectory()) {
+        throw new Error(
+          `MANCODE_ARTIFACT_PATH_UNSAFE: ${relative} cannot be used because ${segments[index]} is not a directory`,
+        );
       }
     } catch (error) {
       if (isNodeError(error) && error.code === 'ENOENT') return;
       throw error;
     }
+  }
+}
+
+async function describeAdapterSymlink(linkPath: string): Promise<string> {
+  try {
+    const resolved = await realpath(linkPath);
+    return ` (resolves to ${resolved})`;
+  } catch {
+    return ' (broken link)';
   }
 }
 

--- a/tests/v3-adapter-contracts.test.ts
+++ b/tests/v3-adapter-contracts.test.ts
@@ -644,6 +644,27 @@ describe('V3 adapter bootstrap integration', () => {
     },
   );
 
+  it.skipIf(process.platform === 'win32')(
+    'names an in-repo symlinked fixed target instead of a bare path error',
+    async () => {
+      await init(root, { v3: true, platform: 'codex' });
+      // Repo convention (e.g. openai/codex): CLAUDE.md mirrors AGENTS.md.
+      await writeFile(
+        path.join(root, 'AGENTS.md'),
+        '# shared agent instructions\n',
+      );
+      await symlink('AGENTS.md', path.join(root, 'CLAUDE.md'));
+
+      await expect(installV3Adapter(root, 'claude-code')).rejects.toThrow(
+        /MANCODE_ARTIFACT_PATH_UNSAFE: CLAUDE\.md is a symbolic link \(resolves to .*AGENTS\.md\)/,
+      );
+      // The link itself is left untouched: mancode never writes through it.
+      await expect(
+        readFile(path.join(root, 'CLAUDE.md'), 'utf8'),
+      ).resolves.toBe('# shared agent instructions\n');
+    },
+  );
+
   it('retires legacy managed entrypoints when repairing an active V3 adapter', async () => {
     await init(root, { v3: true });
     const legacyCodexAlias = path.join(


### PR DESCRIPTION
## Changes

- `fix`: V3 adapter path-safety errors now name the offending path, reason, and remediation instead of a bare `MANCODE_ARTIFACT_PATH_UNSAFE` (fixes the opaque failure when a repo ships `CLAUDE.md -> AGENTS.md` as a symlink, e.g. openai/codex convention).
- Contract test covering the in-repo symlinked target case.

## Verification

- `npx vitest run tests/v3-adapter-contracts.test.ts` (22 passed)
- related adapter suites: adapter-status / adapter-upgrade / beta-gate / read-retry (29 passed)
- `npm run typecheck` + biome clean
- full suite passes with `DSH_SHELL` unset (6 pre-existing failures are caused by `DSH_SHELL=1` leaking into platform-hint detection tests)