### PR TITLE
feat: interactive replace-or-exit choice for symlinked adapter targets

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -15,9 +15,12 @@ import {
   getPlatformInstallers,
 } from '../installers/registry.js';
 import {
+  type V3UnsafeAdapterPath,
   V3_ADAPTER_VERSION,
   assertV3AdapterInstallable,
+  inspectUnsafeV3AdapterPaths,
   inspectV3Adapter,
+  replaceUnsafeV3AdapterSymlinks,
 } from '../installers/v3-adapter.js';
 import { detectTeamStatus } from '../system/detect-team.js';
 import { detectSystemDeps } from '../system/detect.js';
@@ -753,6 +756,14 @@ async function initializeV3(
     return EXIT_INIT_FAILED;
   }
   try {
+    if (!existingV3) {
+      const unsafeExit = await resolveUnsafeInitAdapterPaths(
+        rootDir,
+        options,
+        selectedPlatforms,
+      );
+      if (unsafeExit !== null) return unsafeExit;
+    }
     if (
       existingV3 &&
       selectedPlatforms.some((platform) => !registeredAdapters.has(platform))
@@ -806,6 +817,48 @@ async function initializeV3(
     printV3InitError(error);
     return EXIT_INIT_FAILED;
   }
+}
+
+/**
+ * Interactive greenfield init: when a fixed adapter target is a symlink,
+ * offer the user a clean exit or replace the link with a regular file that
+ * preserves the resolved content, then let installation continue.
+ */
+async function resolveUnsafeInitAdapterPaths(
+  rootDir: string,
+  options: InitOptions,
+  selectedPlatforms: PlatformName[],
+): Promise<number | null> {
+  const prompter =
+    options.prompter ?? (options.interactive ? createTerminalPrompter() : null);
+  if (!prompter) return null;
+  const locale = detectInitLocale(options.lang) ?? 'en';
+  const found: V3UnsafeAdapterPath[] = [];
+  const seen = new Set<string>();
+  for (const platform of selectedPlatforms) {
+    for (const entry of await inspectUnsafeV3AdapterPaths(rootDir, platform)) {
+      if (seen.has(entry.target)) continue;
+      seen.add(entry.target);
+      found.push(entry);
+    }
+  }
+  const fixable = found.filter(
+    (entry) => entry.kind === 'symlink' && entry.finalTarget,
+  );
+  if (fixable.length === 0) return null;
+
+  const choice = await prompter.resolveUnsafeAdapterPaths({
+    locale,
+    paths: found.map(({ relative, resolvedTo }) => ({ relative, resolvedTo })),
+  });
+  if (choice === 'exit') {
+    console.log(
+      locale === 'zh-CN' ? '已取消初始化。' : 'Initialization cancelled.',
+    );
+    return EXIT_USER_CANCEL;
+  }
+  await replaceUnsafeV3AdapterSymlinks(fixable);
+  return null;
 }
 
 function printV3InitError(error: unknown): void {

--- a/src/installers/v3-adapter.ts
+++ b/src/installers/v3-adapter.ts
@@ -2349,10 +2349,10 @@ async function readAdapterTarget(
   return readFile(filePath, 'utf8');
 }
 
-async function assertPlatformAdapterPathsSafe(
+function fixedAdapterTargetPaths(
   root: string,
   platform: PlatformName,
-): Promise<void> {
+): string[] {
   const targets = new Set<string>([
     path.join(root, targetFor(platform)),
     ...V3_MODE_NAMES.map((mode) => v3ModeEntryPath(root, platform, mode)),
@@ -2365,8 +2365,72 @@ async function assertPlatformAdapterPathsSafe(
       targets.add(retired.filePath);
     }
   }
-  for (const target of targets) {
+  return [...targets];
+}
+
+async function assertPlatformAdapterPathsSafe(
+  root: string,
+  platform: PlatformName,
+): Promise<void> {
+  for (const target of fixedAdapterTargetPaths(root, platform)) {
     await assertAdapterPathSafe(root, target);
+  }
+}
+
+/** One unsafe fixed adapter path, reported without writing anything. */
+export interface V3UnsafeAdapterPath {
+  /** Absolute path of the offending entry. */
+  target: string;
+  /** Path relative to the project root. */
+  relative: string;
+  kind: 'symlink' | 'not-directory' | 'outside-root' | 'root-symlink';
+  /** True when the entry is the final fixed target (a file), false for parents. */
+  finalTarget: boolean;
+  /** For symlinks: the resolved absolute path, or null when unresolvable. */
+  resolvedTo: string | null;
+}
+
+/**
+ * Reports every unsafe fixed adapter path for a platform without writing
+ * anything, so interactive flows can offer a remediation before installing.
+ */
+export async function inspectUnsafeV3AdapterPaths(
+  projectRoot: string,
+  platform: PlatformName,
+): Promise<V3UnsafeAdapterPath[]> {
+  const root = path.resolve(projectRoot);
+  const found: V3UnsafeAdapterPath[] = [];
+  const seen = new Set<string>();
+  for (const target of fixedAdapterTargetPaths(root, platform)) {
+    if (seen.has(target)) continue;
+    seen.add(target);
+    const unsafe = await findUnsafeAdapterPathEntry(root, target);
+    if (unsafe !== null) found.push(unsafe);
+  }
+  return found;
+}
+
+/**
+ * Materializes fixable final-target symlinks as regular files that copy the
+ * resolved content, so a confirmed init can continue without losing what the
+ * link used to expose. Escaping parents and broken links are left untouched.
+ */
+export async function replaceUnsafeV3AdapterSymlinks(
+  entries: readonly V3UnsafeAdapterPath[],
+): Promise<void> {
+  for (const entry of entries) {
+    if (
+      entry.kind !== 'symlink' ||
+      !entry.finalTarget ||
+      entry.resolvedTo === null
+    ) {
+      continue;
+    }
+    const resolvedEntry = await lstat(entry.resolvedTo).catch(() => null);
+    if (resolvedEntry === null || !resolvedEntry.isFile()) continue;
+    const content = await readFile(entry.resolvedTo);
+    await rm(entry.target, { force: true });
+    await writeFile(entry.target, content);
   }
 }
 
@@ -2375,17 +2439,58 @@ async function assertAdapterPathSafe(
   root: string,
   target: string,
 ): Promise<void> {
-  const relative = path.relative(root, target);
-  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+  const unsafe = await findUnsafeAdapterPathEntry(root, target);
+  if (unsafe === null) return;
+  if (unsafe.kind === 'outside-root') {
     throw new Error(
       `MANCODE_ARTIFACT_PATH_UNSAFE: adapter target must stay inside the project root: ${target}`,
     );
   }
-  const rootEntry = await lstat(root);
-  if (!rootEntry.isDirectory() || rootEntry.isSymbolicLink()) {
+  if (unsafe.kind === 'root-symlink') {
     throw new Error(
       `MANCODE_ARTIFACT_PATH_UNSAFE: project root must be a real directory, not a symbolic link: ${root}`,
     );
+  }
+  if (unsafe.kind === 'not-directory') {
+    throw new Error(
+      `MANCODE_ARTIFACT_PATH_UNSAFE: ${unsafe.relative} cannot be used because ${path.basename(unsafe.target)} is not a directory`,
+    );
+  }
+  const detail = unsafe.resolvedTo
+    ? ` (resolves to ${unsafe.resolvedTo})`
+    : ' (broken link)';
+  const replacement = unsafe.finalTarget
+    ? 'a regular file'
+    : 'a real directory';
+  throw new Error(
+    `MANCODE_ARTIFACT_PATH_UNSAFE: ${unsafe.relative} is a symbolic link${detail}; mancode never writes through links. Replace it with ${replacement} before initializing the adapter.`,
+  );
+}
+
+/** Finds the first unsafe entry in one fixed adapter path, or null when safe. */
+async function findUnsafeAdapterPathEntry(
+  root: string,
+  target: string,
+): Promise<V3UnsafeAdapterPath | null> {
+  const relative = path.relative(root, target);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    return {
+      target,
+      relative,
+      kind: 'outside-root',
+      finalTarget: false,
+      resolvedTo: null,
+    };
+  }
+  const rootEntry = await lstat(root);
+  if (!rootEntry.isDirectory() || rootEntry.isSymbolicLink()) {
+    return {
+      target: root,
+      relative,
+      kind: 'root-symlink',
+      finalTarget: false,
+      resolvedTo: null,
+    };
   }
   const segments = relative.split(path.sep);
   let current = root;
@@ -2394,31 +2499,36 @@ async function assertAdapterPathSafe(
     try {
       const entry = await lstat(current);
       if (entry.isSymbolicLink()) {
-        const detail = await describeAdapterSymlink(current);
-        const replacement =
-          index === segments.length - 1 ? 'a regular file' : 'a real directory';
-        throw new Error(
-          `MANCODE_ARTIFACT_PATH_UNSAFE: ${relative} is a symbolic link${detail}; mancode never writes through links. Replace it with ${replacement} before initializing the adapter.`,
-        );
+        return {
+          target: current,
+          relative,
+          kind: 'symlink',
+          finalTarget: index === segments.length - 1,
+          resolvedTo: await resolveAdapterSymlink(current),
+        };
       }
       if (index < segments.length - 1 && !entry.isDirectory()) {
-        throw new Error(
-          `MANCODE_ARTIFACT_PATH_UNSAFE: ${relative} cannot be used because ${segments[index]} is not a directory`,
-        );
+        return {
+          target: current,
+          relative,
+          kind: 'not-directory',
+          finalTarget: false,
+          resolvedTo: null,
+        };
       }
     } catch (error) {
-      if (isNodeError(error) && error.code === 'ENOENT') return;
+      if (isNodeError(error) && error.code === 'ENOENT') return null;
       throw error;
     }
   }
+  return null;
 }
 
-async function describeAdapterSymlink(linkPath: string): Promise<string> {
+async function resolveAdapterSymlink(linkPath: string): Promise<string | null> {
   try {
-    const resolved = await realpath(linkPath);
-    return ` (resolves to ${resolved})`;
+    return await realpath(linkPath);
   } catch {
-    return ' (broken link)';
+    return null;
   }
 }
 

--- a/src/system/init-onboarding.ts
+++ b/src/system/init-onboarding.ts
@@ -20,6 +20,10 @@ export interface InitPrompter {
     locale: InitLocale;
     detected: PlatformName[];
   }): Promise<PlatformName[] | null>;
+  resolveUnsafeAdapterPaths(context: {
+    locale: InitLocale;
+    paths: readonly { relative: string; resolvedTo: string | null }[];
+  }): Promise<'replace' | 'exit'>;
 }
 
 const ALL_PLATFORMS = Object.keys(PLATFORM_INSTALLERS) as PlatformName[];
@@ -258,6 +262,36 @@ export function createTerminalPrompter(): InitPrompter {
           selected.push(platform);
         }
         return [...new Set(selected)];
+      } finally {
+        rl.close();
+      }
+    },
+    async resolveUnsafeAdapterPaths({ locale, paths }) {
+      const rl = createInterface({ input: stdin, output: stdout });
+      try {
+        console.log(
+          locale === 'zh-CN'
+            ? '\n检测到适配器目标路径是符号链接（mancode 不会写入链接）：'
+            : '\nAdapter target paths are symbolic links (mancode never writes through links):',
+        );
+        for (const item of paths) {
+          const detail = item.resolvedTo ? ` -> ${item.resolvedTo}` : '';
+          console.log(`  ${item.relative}${detail}`);
+        }
+        console.log(locale === 'zh-CN' ? '1. 退出' : '1. Exit');
+        console.log(
+          locale === 'zh-CN'
+            ? '2. 将符号链接替换为普通文件（保留原内容）并继续初始化'
+            : '2. Replace the symbolic link(s) with regular file(s) (content preserved) and continue',
+        );
+        const answer = (
+          await rl.question(
+            locale === 'zh-CN' ? '选择 [1/2]: ' : 'Choose [1/2]: ',
+          )
+        )
+          .trim()
+          .toLowerCase();
+        return answer === '2' ? 'replace' : 'exit';
       } finally {
         rl.close();
       }

--- a/tests/init-onboarding.test.ts
+++ b/tests/init-onboarding.test.ts
@@ -43,6 +43,7 @@ const PLATFORM_HINT_ENV_VARS = [
   'CURSOR_TRACE_ID',
   'COPILOT_AGENT',
   'GITHUB_COPILOT',
+  'DSH_SHELL',
 ] as const;
 
 describe('init onboarding', () => {

--- a/tests/v3-adapter-contracts.test.ts
+++ b/tests/v3-adapter-contracts.test.ts
@@ -1,4 +1,11 @@
-import { mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import {
+  lstat,
+  mkdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -19,9 +26,11 @@ import type { PlatformName } from '../src/installers/registry.js';
 import {
   V3_ADAPTER_PLATFORMS,
   V3_MODE_NAMES,
+  inspectUnsafeV3AdapterPaths,
   inspectV3Adapter,
   installV3Adapter,
   removeV3Adapter,
+  replaceUnsafeV3AdapterSymlinks,
   stageV3Adapter,
   v3ModeEntryPath,
 } from '../src/installers/v3-adapter.js';
@@ -662,6 +671,74 @@ describe('V3 adapter bootstrap integration', () => {
       await expect(
         readFile(path.join(root, 'CLAUDE.md'), 'utf8'),
       ).resolves.toBe('# shared agent instructions\n');
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'reports an in-repo symlinked fixed target through the inspection API',
+    async () => {
+      await init(root, { v3: true, platform: 'codex' });
+      await symlink('AGENTS.md', path.join(root, 'CLAUDE.md'));
+
+      const found = await inspectUnsafeV3AdapterPaths(root, 'claude-code');
+      expect(found).toHaveLength(1);
+      expect(found[0]).toMatchObject({
+        relative: 'CLAUDE.md',
+        kind: 'symlink',
+        finalTarget: true,
+      });
+      expect(found[0]?.resolvedTo?.endsWith('AGENTS.md')).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'materializes a symlinked fixed target as a regular file with preserved content',
+    async () => {
+      await init(root, { v3: true, platform: 'codex' });
+      await writeFile(
+        path.join(root, 'AGENTS.md'),
+        '# shared agent instructions\n',
+      );
+      await symlink('AGENTS.md', path.join(root, 'CLAUDE.md'));
+
+      const found = await inspectUnsafeV3AdapterPaths(root, 'claude-code');
+      await replaceUnsafeV3AdapterSymlinks(found);
+
+      const entry = await lstat(path.join(root, 'CLAUDE.md'));
+      expect(entry.isSymbolicLink()).toBe(false);
+      await expect(
+        readFile(path.join(root, 'CLAUDE.md'), 'utf8'),
+      ).resolves.toBe('# shared agent instructions\n');
+
+      const status = await installV3Adapter(root, 'claude-code');
+      expect(status.ready).toBe(true);
+      const content = await readFile(path.join(root, 'CLAUDE.md'), 'utf8');
+      expect(content).toContain('# shared agent instructions');
+      expect(content).toContain('mancode:continuity:claude:start');
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'leaves an escaping symlinked parent unreplaced and still rejects install',
+    async () => {
+      await init(root, { v3: true });
+      const outside = `${root}-outside`;
+      await mkdir(outside, { recursive: true });
+      try {
+        await symlink(outside, path.join(root, '.agents'));
+
+        const found = await inspectUnsafeV3AdapterPaths(root, 'codex');
+        expect(found.some((entry) => entry.kind === 'symlink')).toBe(true);
+        await replaceUnsafeV3AdapterSymlinks(found);
+        await expect(installV3Adapter(root, 'codex')).rejects.toThrow(
+          'MANCODE_ARTIFACT_PATH_UNSAFE',
+        );
+        await expect(
+          readFile(path.join(outside, 'AGENTS.md')),
+        ).rejects.toThrow();
+      } finally {
+        await rm(outside, { recursive: true, force: true });
+      }
     },
   );
 

--- a/tests/v3-init-command.test.ts
+++ b/tests/v3-init-command.test.ts
@@ -1,4 +1,11 @@
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+  lstat,
+  mkdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import os, { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
@@ -16,6 +23,7 @@ import {
   EXIT_INIT_FAILED,
   EXIT_NOT_A_PROJECT_DIR,
   EXIT_OK,
+  EXIT_USER_CANCEL,
   init,
   resolveInitAuthority,
 } from '../src/commands/init.js';
@@ -30,6 +38,7 @@ const PLATFORM_HINT_ENV_VARS = [
   'CURSOR_TRACE_ID',
   'COPILOT_AGENT',
   'GITHUB_COPILOT',
+  'DSH_SHELL',
 ] as const;
 
 describe('journaled V3 init command', () => {
@@ -98,6 +107,7 @@ describe('journaled V3 init command', () => {
           return true;
         },
         selectPlatforms: async () => ['cursor'],
+        resolveUnsafeAdapterPaths: async () => 'exit',
       },
     });
 
@@ -281,6 +291,7 @@ describe('journaled V3 init command', () => {
             platformPrompted = true;
             return ['codex'];
           },
+          resolveUnsafeAdapterPaths: async () => 'exit',
         },
       }),
     ).toBe(EXIT_INIT_FAILED);
@@ -323,4 +334,67 @@ describe('journaled V3 init command', () => {
       readFile(path.join(root, '.mancode', 'schema.json'), 'utf8'),
     ).rejects.toThrow();
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'replaces a symlinked adapter target with a regular file when confirmed',
+    async () => {
+      await mkdir(path.join(root, '.git'));
+      await writeFile(
+        path.join(root, 'AGENTS.md'),
+        '# shared agent instructions\n',
+      );
+      await symlink('AGENTS.md', path.join(root, 'CLAUDE.md'));
+      let promptedPaths: string[] = [];
+
+      const result = await init(root, {
+        fromCli: true,
+        interactive: true,
+        prompter: {
+          confirmGenericProject: async () => true,
+          selectPlatforms: async () => ['claude-code'],
+          resolveUnsafeAdapterPaths: async (context) => {
+            promptedPaths = context.paths.map((item) => item.relative);
+            return 'replace';
+          },
+        },
+      });
+
+      expect(result).toBe(EXIT_OK);
+      expect(promptedPaths).toContain('CLAUDE.md');
+      const entry = await lstat(path.join(root, 'CLAUDE.md'));
+      expect(entry.isSymbolicLink()).toBe(false);
+      const content = await readFile(path.join(root, 'CLAUDE.md'), 'utf8');
+      expect(content).toContain('# shared agent instructions');
+      expect(content).toContain('mancode:continuity:claude:start');
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'lets the user exit cleanly instead of touching the symlink',
+    async () => {
+      await mkdir(path.join(root, '.git'));
+      await writeFile(
+        path.join(root, 'AGENTS.md'),
+        '# shared agent instructions\n',
+      );
+      await symlink('AGENTS.md', path.join(root, 'CLAUDE.md'));
+
+      const result = await init(root, {
+        fromCli: true,
+        interactive: true,
+        prompter: {
+          confirmGenericProject: async () => true,
+          selectPlatforms: async () => ['claude-code'],
+          resolveUnsafeAdapterPaths: async () => 'exit',
+        },
+      });
+
+      expect(result).toBe(EXIT_USER_CANCEL);
+      const entry = await lstat(path.join(root, 'CLAUDE.md'));
+      expect(entry.isSymbolicLink()).toBe(true);
+      await expect(
+        readFile(path.join(root, '.mancode', 'schema.json'), 'utf8'),
+      ).rejects.toThrow();
+    },
+  );
 });


### PR DESCRIPTION
## 背景

`mancode init` 遇到仓库里固定适配器目标为符号链接（如 `CLAUDE.md -> AGENTS.md`，openai/codex 惯例）时不再直接报错：交互式初始化会先检测，然后给用户两个选项：

1. **退出**（干净取消，不写任何文件）；
2. **将符号链接替换为普通文件并继续**（复制链接解析目标的内容，原内容保留，之后 mancode 托管块照常追加）。

非交互调用（无 TTY）保持原有描述性错误不变。

## 变更

- `v3-adapter.ts`：新增 `inspectUnsafeV3AdapterPaths` / `replaceUnsafeV3AdapterSymlinks`；安全检查重构为共享的收集式 walker，报错文案不变
- `init-onboarding.ts`：`InitPrompter.resolveUnsafeAdapterPaths` + 终端提示（中英双语）
- `init.ts`：greenfield V3 流程接入检测-询问-替换
- 测试：inspect/replace 契约测试；交互两个分支的集成测试；`DSH_SHELL` 补入平台提示环境变量 scrub（修复在 DeepSeek Harness 会话内跑 `npm test` 时 6 个用例的误失败）

## 验证

- 全量测试 127 文件 / 939 用例通过（未 unset 环境变量）
- typecheck + biome 通过
- 伪终端端到端验证：选 2 → 链接变为普通文件、原内容保留、8 平台全部初始化完成；选 1 → 干净退出、链接与仓库均未改动